### PR TITLE
fix: batch TrackId table integration checks

### DIFF
--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -318,19 +318,25 @@ var mdbTrackidTableBatchQueue = {},
     mdbTrackidBatchMaxUrlsPerRequest = 25,
     mdbTrackidBatchMaxQueryLength = 1800;
 
+function buildTrackIdBatchQueryValue( playerUrls ) {
+    return encodeURIComponent( playerUrls.join( "|" ) );
+}
+
 // Split one large table scan into bounded batch requests.
-// The userscript previously called the single-item API once per row.
+// MediaWiki multi-value GET params are pipe-delimited inside one param value,
+// not repeated as &urls=a&urls=b.
 function chunkTrackIdBatchPlayerUrls( playerUrls ) {
     var chunks = [],
         oversizedUrls = [],
         currentChunk = [],
-        baseLength = ( apiUrl_mw + "?action=mixesdbtrackidbatch&format=json" ).length,
-        currentLength = baseLength;
+        baseLength = ( apiUrl_mw + "?action=mixesdbtrackidbatch&format=json&urls=" ).length;
 
     $.each( playerUrls, function( index, playerUrl ) {
-        var queryPart = "&urls=" + encodeURIComponent( playerUrl );
+        var singleUrlLength = baseLength + buildTrackIdBatchQueryValue( [ playerUrl ] ).length,
+            nextChunk = currentChunk.concat( [ playerUrl ] ),
+            nextChunkLength = baseLength + buildTrackIdBatchQueryValue( nextChunk ).length;
 
-        if( baseLength + queryPart.length > mdbTrackidBatchMaxQueryLength ) {
+        if( singleUrlLength > mdbTrackidBatchMaxQueryLength ) {
             oversizedUrls.push( playerUrl );
             return;
         }
@@ -339,16 +345,15 @@ function chunkTrackIdBatchPlayerUrls( playerUrls ) {
             currentChunk.length > 0
             && (
                 currentChunk.length >= mdbTrackidBatchMaxUrlsPerRequest
-                || currentLength + queryPart.length > mdbTrackidBatchMaxQueryLength
+                || nextChunkLength > mdbTrackidBatchMaxQueryLength
             )
         ) {
             chunks.push( currentChunk );
-            currentChunk = [];
-            currentLength = baseLength;
+            currentChunk = [ playerUrl ];
+            return;
         }
 
-        currentChunk.push( playerUrl );
-        currentLength += queryPart.length;
+        currentChunk = nextChunk;
     });
 
     if( currentChunk.length > 0 ) {
@@ -522,10 +527,7 @@ function flushTableTidIntegrationChecks() {
         var apiQueryUrl = apiUrl_mw;
         apiQueryUrl += "?action=mixesdbtrackidbatch";
         apiQueryUrl += "&format=json";
-
-        $.each( playerUrlChunk, function( index, playerUrl ) {
-            apiQueryUrl += "&urls=" + encodeURIComponent( playerUrl );
-        });
+        apiQueryUrl += "&urls=" + buildTrackIdBatchQueryValue( playerUrlChunk );
 
         logVar( "apiQueryUrl_batch", apiQueryUrl );
 

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -366,16 +366,19 @@ function chunkTrackIdBatchPlayerUrls( playerUrls ) {
     };
 }
 
-function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
+function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter, options ) {
     var currentUsername = $(".user-name").text(),
         allowUserTableMarking = ["Schrute_Inc.", "Komapatient"].includes(currentUsername),
         dashText = '<span class="tooltip-title" title="Status is not ready">&ndash;</span>',
         notYetIntegratedText = '<span class="tooltip-title small" title="This tracklist is not intergated yet to the found mix page">not yet</span>',
+        noPageFoundText = '<span class="tooltip-title small" title="No MixesDB mix page found using this player">not found</span>',
         resultItems = Array.isArray( data.mixesdbtrackid ) ? data.mixesdbtrackid : [],
         mixesdbPages = ( resultItems[0] && Array.isArray( resultItems[0].mixesdbpages ) ) ? resultItems[0].mixesdbpages : [],
         firstMixesdbPage = mixesdbPages[0] || null,
         checked_pageId = firstMixesdbPage ? firstMixesdbPage.page_id : "",
         checked_url = firstMixesdbPage ? firstMixesdbPage.url : "";
+
+    options = options || {};
 
     waiter = waiter || $("waiter", wrapper);
     waiter.remove();
@@ -421,8 +424,14 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
             }
         }
     } else {
-        // Preserve the old recovery path for rows that do not come back with a direct page_id.
-        // Batching reduces request fan-out, but table behavior should stay familiar.
+        if( options.skipSearchFallback ) {
+            // Batch callers already asked MixesDB about this player URL.
+            // Do not fan back out into per-row lookups when no page_id comes back.
+            wrapper.append( noPageFoundText );
+            return;
+        }
+
+        // Preserve the old recovery path for legacy single-item checks.
         log( "No checked_pageId! Run searchKeywords API for player URL to get the mdbPageId" );
 
         var apiQueryUrl = apiUrl_searchKeywords_fromUrl( tidPlayerUrl );
@@ -571,7 +580,9 @@ function flushTableTidIntegrationChecks() {
                         };
 
                     $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
-                        renderTableTrackIdCheckResult( playerUrl, wrapper, tableData, $("waiter", wrapper) );
+                        renderTableTrackIdCheckResult( playerUrl, wrapper, tableData, $("waiter", wrapper), {
+                            skipSearchFallback: true
+                        } );
                     });
                 });
             },

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TrackId.net (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.05.2
+// @version      2026.05.15.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -284,96 +284,9 @@ function checkTidIntegration( tidPlayerUrl="", mdbPageId="", action="", wrapper=
                                     wrapper.show();
                                 }
 
-                                // Add checkbox in tables for certain users
-                                var currentUsername = $(".user-name").text(),
-                                    allowUserTableMarking = ["Schrute_Inc.", "Komapatient"].includes(currentUsername);
-
-                                var dashText = '<span class="tooltip-title" title="Status is not ready">&ndash;</span>',
-                                    notYetIntegratedText = '<span class="tooltip-title small" title="This tracklist is not intergated yet to the found mix page">not yet</span>';
-
                                 // tables
                                 if( target == "table" ) {
-                                    waiter.remove();
-
-
-                                    if( checked_pageId ) {
-                                        var lastCheckedAgainstMixesDB = data.mixesdbtrackid[0].mixesdbpages[0].lastCheckedAgainstMixesDB;
-
-                                        logVar( "lastCheckedAgainstMixesDB", lastCheckedAgainstMixesDB );
-
-                                        if( lastCheckedAgainstMixesDB != null && lastCheckedAgainstMixesDB != "empty" ) {
-                                            log( "Checked and page found: ("+checked_pageId+")" );
-
-                                            var checkedLink = '<a href="'+checked_url+'">'+checkIcon+'</a>';
-
-                                            wrapper.append( checkedLink );
-                                        } else {
-                                            var status_td = wrapper.prev("td.status"),
-                                                status = $("div.MuiBox-root",status_td).attr("aria-label").trim();
-
-                                            logVar( "status", status );
-
-                                            if( status == "Tracklist ready" ) {
-                                                if( allowUserTableMarking ) {
-                                                    var input = make_mdbTrackidCheck_input( tidPlayerUrl, checked_pageId, "table" );
-                                                    wrapper.append( input );
-                                                } else {
-                                                    wrapper.append( notYetIntegratedText );
-                                                }
-                                            } else {
-                                                wrapper.append( dashText );
-                                            }
-                                        }
-                                    } else {
-                                        log( "No checked_pageId! Run searchKeywords API for player URL to get the mdbPageId" );
-
-                                        var apiQueryUrl = apiUrl_searchKeywords_fromUrl( tidPlayerUrl );
-                                        logVar( "apiQueryUrl", apiQueryUrl );
-
-                                        $.ajax({
-                                            url: apiQueryUrl,
-                                            type: 'get',
-                                            dataType: 'json',
-                                            async: false,
-                                            success: function(data) {
-                                                var resultNum = data["query"]["searchinfo"]["totalhits"];
-                                                if( resultNum == 1 ) {
-                                                    // @TODO DRY
-                                                    var resultsArr = data["query"]["search"],
-                                                        mdbPageId = resultsArr[0].pageid;
-
-                                                    if( mdbPageId ) {
-                                                        var status_td = wrapper.prev("td.status"),
-                                                            status = $("div.MuiBox-root",status_td).attr("aria-label").trim();
-
-                                                        logVar( "status", status );
-
-                                                        if( status == "Tracklist ready" ) {
-                                                            if( allowUserTableMarking ) {
-                                                                var input = make_mdbTrackidCheck_input( tidPlayerUrl, mdbPageId, "table" );
-                                                                wrapper.append( input );
-                                                            } else {
-                                                                wrapper.append( notYetIntegratedText );
-                                                            }
-                                                        } else {
-                                                            wrapper.append( dashText );
-                                                        }
-                                                    } else {
-                                                        wrapper.append( notYetIntegratedText );
-                                                    }
-                                                } else {
-                                                    log( "resultNum != 1: " + resultNum );
-
-                                                    if( resultNum == 0 ) {
-                                                        wrapper.append( '<span class="tooltip-title small" title="No MixesDB mix page found using this player">not found</span>' );
-                                                    }
-                                                    if( resultNum > 1 ) {
-                                                        wrapper.append( '<span class="tooltip-title small" title="Bug: Too many results">multiple pages using this</span>' );
-                                                    }
-                                                }
-                                            }
-                                        }); // end ajax
-                                    }
+                                    renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter );
                                 }
                             }
                         }
@@ -398,6 +311,199 @@ function checkTidIntegration( tidPlayerUrl="", mdbPageId="", action="", wrapper=
                 break;
         }
     }
+}
+
+var mdbTrackidTableBatchQueue = {},
+    mdbTrackidTableBatchTimer = null;
+
+function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
+    var currentUsername = $(".user-name").text(),
+        allowUserTableMarking = ["Schrute_Inc.", "Komapatient"].includes(currentUsername),
+        dashText = '<span class="tooltip-title" title="Status is not ready">&ndash;</span>',
+        notYetIntegratedText = '<span class="tooltip-title small" title="This tracklist is not intergated yet to the found mix page">not yet</span>',
+        checked_pageId = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].page_id : "",
+        checked_url = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].url : "";
+
+    waiter = waiter || $("waiter", wrapper);
+    waiter.remove();
+
+    if( data.error && data.error.code == "notfound" ) {
+        wrapper.append( '<span class="tooltip-title" title="TrackId.net page not found (recently created?)">&ndash;</span>' );
+        return;
+    }
+
+    if( checked_pageId ) {
+        var lastCheckedAgainstMixesDB = data.mixesdbtrackid[0].mixesdbpages[0].lastCheckedAgainstMixesDB;
+
+        logVar( "lastCheckedAgainstMixesDB", lastCheckedAgainstMixesDB );
+
+        if( lastCheckedAgainstMixesDB != null && lastCheckedAgainstMixesDB != "empty" ) {
+            log( "Checked and page found: ("+checked_pageId+")" );
+
+            var checkedLink = '<a href="'+checked_url+'">'+checkIcon+'</a>';
+
+            wrapper.append( checkedLink );
+        } else {
+            var status_td = wrapper.prev("td.status"),
+                status = $("div.MuiBox-root",status_td).attr("aria-label").trim();
+
+            logVar( "status", status );
+
+            if( status == "Tracklist ready" ) {
+                if( allowUserTableMarking ) {
+                    var input = make_mdbTrackidCheck_input( tidPlayerUrl, checked_pageId, "table" );
+                    wrapper.append( input );
+                } else {
+                    wrapper.append( notYetIntegratedText );
+                }
+            } else {
+                wrapper.append( dashText );
+            }
+        }
+    } else {
+        log( "No checked_pageId! Run searchKeywords API for player URL to get the mdbPageId" );
+
+        var apiQueryUrl = apiUrl_searchKeywords_fromUrl( tidPlayerUrl );
+        logVar( "apiQueryUrl", apiQueryUrl );
+
+        $.ajax({
+            url: apiQueryUrl,
+            type: 'get',
+            dataType: 'json',
+            async: false,
+            success: function(data) {
+                var resultNum = data["query"]["searchinfo"]["totalhits"];
+                if( resultNum == 1 ) {
+                    var resultsArr = data["query"]["search"],
+                        mdbPageId = resultsArr[0].pageid;
+
+                    if( mdbPageId ) {
+                        var status_td = wrapper.prev("td.status"),
+                            status = $("div.MuiBox-root",status_td).attr("aria-label").trim();
+
+                        logVar( "status", status );
+
+                        if( status == "Tracklist ready" ) {
+                            if( allowUserTableMarking ) {
+                                var input = make_mdbTrackidCheck_input( tidPlayerUrl, mdbPageId, "table" );
+                                wrapper.append( input );
+                            } else {
+                                wrapper.append( notYetIntegratedText );
+                            }
+                        } else {
+                            wrapper.append( dashText );
+                        }
+                    } else {
+                        wrapper.append( notYetIntegratedText );
+                    }
+                } else {
+                    log( "resultNum != 1: " + resultNum );
+
+                    if( resultNum == 0 ) {
+                        wrapper.append( '<span class="tooltip-title small" title="No MixesDB mix page found using this player">not found</span>' );
+                    }
+                    if( resultNum > 1 ) {
+                        wrapper.append( '<span class="tooltip-title small" title="Bug: Too many results">multiple pages using this</span>' );
+                    }
+                }
+            }
+        });
+    }
+}
+
+function queueTableTidIntegrationCheck( wrapper ) {
+    var playerUrl = wrapper.attr("data-tidplayerurl");
+
+    if( !playerUrl || playerUrl == "undefined" ) {
+        return;
+    }
+
+    if( !mdbTrackidTableBatchQueue[playerUrl] ) {
+        mdbTrackidTableBatchQueue[playerUrl] = [];
+    }
+
+    mdbTrackidTableBatchQueue[playerUrl].push( wrapper );
+
+    if( mdbTrackidTableBatchTimer ) {
+        clearTimeout( mdbTrackidTableBatchTimer );
+    }
+
+    mdbTrackidTableBatchTimer = setTimeout( flushTableTidIntegrationChecks, 50 );
+}
+
+function flushTableTidIntegrationChecks() {
+    var playerUrls = Object.keys( mdbTrackidTableBatchQueue );
+
+    if( playerUrls.length === 0 ) {
+        return;
+    }
+
+    var queue = mdbTrackidTableBatchQueue;
+    mdbTrackidTableBatchQueue = {};
+    mdbTrackidTableBatchTimer = null;
+
+    var apiQueryUrl = apiUrl_mw;
+    apiQueryUrl += "?action=mixesdbtrackidbatch";
+    apiQueryUrl += "&format=json";
+
+    $.each( playerUrls, function( index, playerUrl ) {
+        apiQueryUrl += "&urls=" + encodeURIComponent( playerUrl );
+    });
+
+    logVar( "apiQueryUrl_batch", apiQueryUrl );
+
+    $.ajax({
+        url: apiQueryUrl,
+        type: 'get',
+        dataType: 'json',
+        async: true,
+        success: function(data) {
+            if( data.error ) {
+                $.each( playerUrls, function( index, playerUrl ) {
+                    $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
+                        renderTableTrackIdCheckResult( playerUrl, wrapper, { error: data.error }, $("waiter", wrapper) );
+                    });
+                });
+                return;
+            }
+
+            var resultsByUrl = {};
+
+            $.each( data.mixesdbtrackidbatch || [], function( index, result ) {
+                resultsByUrl[result.requestedurl] = result;
+                if( result.sanitizedurl ) {
+                    resultsByUrl[result.sanitizedurl] = result;
+                }
+            });
+
+            $.each( playerUrls, function( index, playerUrl ) {
+                var result = resultsByUrl[playerUrl] || {
+                        error: {
+                            code: "notfound",
+                            info: "No matching data found for the given URL",
+                            url: playerUrl
+                        }
+                    },
+                    tableData = {
+                        mixesdbtrackid: result.mixesdbtrackid,
+                        error: result.error
+                    };
+
+                $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
+                    renderTableTrackIdCheckResult( playerUrl, wrapper, tableData, $("waiter", wrapper) );
+                });
+            });
+        },
+        error: function() {
+            $.each( playerUrls, function( index, playerUrl ) {
+                $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
+                    var waiter = $("waiter", wrapper);
+                    waiter.remove();
+                    wrapper.append( '<span class="tooltip-title" title="TrackId.net batch check failed">&ndash;</span>' );
+                });
+            });
+        }
+    });
 }
 
 /*
@@ -432,11 +538,7 @@ waitForKeyElements("#mdbTrackidCheck-wrapper", function( jNode ) {
  * tables
  */
 waitForKeyElements(".mdb-tid-table td.mdbTrackidCheck", function( jNode ) {
-    var playerUrl = jNode.attr("data-tidplayerurl");
-
-    if( playerUrl != "undefined" ) {
-        checkTidIntegration( playerUrl, null, "check", jNode , "table" );
-    }
+    queueTableTidIntegrationCheck( jNode );
 });
 
 waitForKeyElements(".mdb-tid-table td.mdbTrackidCheck input[type=checkbox]", function( jNode ) {

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -317,6 +317,9 @@ var mdbTrackidTableBatchQueue = {},
     mdbTrackidTableBatchTimer = null,
     mdbTrackidBatchMaxUrlsPerRequest = 25,
     mdbTrackidBatchMaxQueryLength = 1800;
+
+// Split one large table scan into bounded batch requests.
+// The userscript previously called the single-item API once per row.
 function chunkTrackIdBatchPlayerUrls( playerUrls ) {
     var chunks = [],
         oversizedUrls = [],
@@ -372,6 +375,8 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
     waiter = waiter || $("waiter", wrapper);
     waiter.remove();
 
+    // Treat explicit API errors as terminal row states.
+    // Missing rows are handled below by the existing search-keyword fallback.
     if( data.error && data.error.code == "notfound" ) {
         wrapper.append( '<span class="tooltip-title" title="TrackId.net page not found (recently created?)">&ndash;</span>' );
         return;
@@ -411,6 +416,8 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
             }
         }
     } else {
+        // Preserve the old recovery path for rows that do not come back with a direct page_id.
+        // Batching reduces request fan-out, but table behavior should stay familiar.
         log( "No checked_pageId! Run searchKeywords API for player URL to get the mdbPageId" );
 
         var apiQueryUrl = apiUrl_searchKeywords_fromUrl( tidPlayerUrl );
@@ -472,12 +479,15 @@ function queueTableTidIntegrationCheck( wrapper ) {
         mdbTrackidTableBatchQueue[playerUrl] = [];
     }
 
+    // Multiple rows can point at the same player URL.
+    // Queue all wrappers so one batch result can update every matching cell.
     mdbTrackidTableBatchQueue[playerUrl].push( wrapper );
 
     if( mdbTrackidTableBatchTimer ) {
         clearTimeout( mdbTrackidTableBatchTimer );
     }
 
+    // Small debounce window so rows discovered together become one request burst.
     mdbTrackidTableBatchTimer = setTimeout( flushTableTidIntegrationChecks, 50 );
 }
 
@@ -494,6 +504,8 @@ function flushTableTidIntegrationChecks() {
 
     var batchPlan = chunkTrackIdBatchPlayerUrls( playerUrls );
 
+    // If one URL is too large even by itself, surface that row locally instead of
+    // sending an oversized request that can fail the whole batch unexpectedly.
     $.each( batchPlan.oversizedUrls, function( index, playerUrl ) {
         $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
             renderTableTrackIdCheckResult( playerUrl, wrapper, {
@@ -535,6 +547,8 @@ function flushTableTidIntegrationChecks() {
                 }
 
                 $.each( data.mixesdbtrackidbatch || [], function( index, result ) {
+                    // The batch API echoes both requestedurl and sanitizedurl.
+                    // Index both so the table lookup can tolerate backend normalization.
                     if( result.requestedurl ) {
                         resultsByUrl[result.requestedurl] = result;
                     }
@@ -549,6 +563,8 @@ function flushTableTidIntegrationChecks() {
                             mixesdbtrackid: Array.isArray( result.mixesdbtrackid ) ? result.mixesdbtrackid : [],
                             error: result.error
                         } : {
+                            // No direct batch hit: fall through to the existing search-keyword path
+                            // instead of inventing a new table-only row state.
                             mixesdbtrackid: []
                         };
 

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -222,9 +222,9 @@ function checkTidIntegration( tidPlayerUrl="", mdbPageId="", action="", wrapper=
         var apiQueryUrl_check = apiUrl_mw;
         apiQueryUrl_check += "?action=mixesdbtrackid";
         apiQueryUrl_check += "&format=json";
-        apiQueryUrl_check += "&url=" + encodeURIComponent( tidPlayerUrl );
+        apiQueryUrl_check += "&url=" + tidPlayerUrl;
 
-        var apiQueryUrl_save = apiQueryUrl_check + "&page_id=" + encodeURIComponent( mdbPageId );
+        var apiQueryUrl_save = apiQueryUrl_check + "&page_id=" + mdbPageId;
 
         // waiter
         if( target == "table" ) {
@@ -254,14 +254,11 @@ function checkTidIntegration( tidPlayerUrl="", mdbPageId="", action="", wrapper=
                             }
                         // if no error
                         } else {
-                            var directResultItems = Array.isArray( data.mixesdbtrackid ) ? data.mixesdbtrackid : [],
-                                directMixesdbPages = ( directResultItems[0] && Array.isArray( directResultItems[0].mixesdbpages ) ) ? directResultItems[0].mixesdbpages : [],
-                                directFirstMixesdbPage = directMixesdbPages[0] || null,
-                                checked_pageId = directFirstMixesdbPage ? directFirstMixesdbPage.page_id : "",
-                                checked_url = directFirstMixesdbPage ? directFirstMixesdbPage.url : "";
+                            var checked_pageId = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].page_id : "",
+                                checked_url = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].url : "";
 
                             if( checked_pageId == mdbPageId ) {
-                                var lastCheckedAgainstMixesDB = directFirstMixesdbPage ? directFirstMixesdbPage.lastCheckedAgainstMixesDB : null;
+                                var lastCheckedAgainstMixesDB = data.mixesdbtrackid[0].mixesdbpages[0].lastCheckedAgainstMixesDB;
 
                                 if( lastCheckedAgainstMixesDB != null ) {
                                     log( "Is marked as integrated (mdbPageId: " +mdbPageId+ ")" );
@@ -320,39 +317,6 @@ var mdbTrackidTableBatchQueue = {},
     mdbTrackidTableBatchTimer = null,
     mdbTrackidBatchMaxUrlsPerRequest = 25,
     mdbTrackidBatchMaxQueryLength = 1800;
-
-function appendTooltipText( wrapper, text, title, extraClass="" ) {
-    var span = $("<span></span>")
-        .addClass( "tooltip-title" )
-        .attr( "title", title || "" )
-        .html( text );
-
-    if( extraClass ) {
-        span.addClass( extraClass );
-    }
-
-    wrapper.append( span );
-}
-
-function appendSafeCheckedLink( wrapper, checked_url ) {
-    try {
-        var checkedUrlObj = new URL( checked_url, window.location.origin );
-
-        if( !["http:", "https:"].includes( checkedUrlObj.protocol ) ) {
-            appendTooltipText( wrapper, "&ndash;", "MixesDB returned an unsupported link protocol" );
-            return;
-        }
-
-        var checkedLink = $("<a></a>")
-            .attr( "href", checkedUrlObj.href )
-            .append( $( checkIcon ) );
-
-        wrapper.append( checkedLink );
-    } catch( error ) {
-        appendTooltipText( wrapper, "&ndash;", "MixesDB returned an invalid link" );
-    }
-}
-
 function chunkTrackIdBatchPlayerUrls( playerUrls ) {
     var chunks = [],
         oversizedUrls = [],
@@ -397,6 +361,8 @@ function chunkTrackIdBatchPlayerUrls( playerUrls ) {
 function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
     var currentUsername = $(".user-name").text(),
         allowUserTableMarking = ["Schrute_Inc.", "Komapatient"].includes(currentUsername),
+        dashText = '<span class="tooltip-title" title="Status is not ready">&ndash;</span>',
+        notYetIntegratedText = '<span class="tooltip-title small" title="This tracklist is not intergated yet to the found mix page">not yet</span>',
         resultItems = Array.isArray( data.mixesdbtrackid ) ? data.mixesdbtrackid : [],
         mixesdbPages = ( resultItems[0] && Array.isArray( resultItems[0].mixesdbpages ) ) ? resultItems[0].mixesdbpages : [],
         firstMixesdbPage = mixesdbPages[0] || null,
@@ -407,12 +373,12 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
     waiter.remove();
 
     if( data.error && data.error.code == "notfound" ) {
-        appendTooltipText( wrapper, "&ndash;", "TrackId.net page not found (recently created?)" );
+        wrapper.append( '<span class="tooltip-title" title="TrackId.net page not found (recently created?)">&ndash;</span>' );
         return;
     }
 
     if( data.error ) {
-        appendTooltipText( wrapper, "&ndash;", data.error.info || "TrackId.net batch check failed" );
+        wrapper.append( '<span class="tooltip-title" title="' + ( data.error.info || "TrackId.net batch check failed" ) + '">&ndash;</span>' );
         return;
     }
 
@@ -424,7 +390,9 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
         if( lastCheckedAgainstMixesDB != null && lastCheckedAgainstMixesDB != "empty" ) {
             log( "Checked and page found: ("+checked_pageId+")" );
 
-            appendSafeCheckedLink( wrapper, checked_url );
+            var checkedLink = '<a href="'+checked_url+'">'+checkIcon+'</a>';
+
+            wrapper.append( checkedLink );
         } else {
             var status_td = wrapper.prev("td.status"),
                 status = $("div.MuiBox-root",status_td).attr("aria-label").trim();
@@ -436,10 +404,10 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
                     var input = make_mdbTrackidCheck_input( tidPlayerUrl, checked_pageId, "table" );
                     wrapper.append( input );
                 } else {
-                    appendTooltipText( wrapper, "not yet", "This tracklist is not intergated yet to the found mix page", "small" );
+                    wrapper.append( notYetIntegratedText );
                 }
             } else {
-                appendTooltipText( wrapper, "&ndash;", "Status is not ready" );
+                wrapper.append( dashText );
             }
         }
     } else {
@@ -470,22 +438,22 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
                                 var input = make_mdbTrackidCheck_input( tidPlayerUrl, mdbPageId, "table" );
                                 wrapper.append( input );
                             } else {
-                                appendTooltipText( wrapper, "not yet", "This tracklist is not intergated yet to the found mix page", "small" );
+                                wrapper.append( notYetIntegratedText );
                             }
                         } else {
-                            appendTooltipText( wrapper, "&ndash;", "Status is not ready" );
+                            wrapper.append( dashText );
                         }
                     } else {
-                        appendTooltipText( wrapper, "not yet", "This tracklist is not intergated yet to the found mix page", "small" );
+                        wrapper.append( notYetIntegratedText );
                     }
                 } else {
                     log( "resultNum != 1: " + resultNum );
 
                     if( resultNum == 0 ) {
-                        appendTooltipText( wrapper, "not found", "No MixesDB mix page found using this player", "small" );
+                        wrapper.append( '<span class="tooltip-title small" title="No MixesDB mix page found using this player">not found</span>' );
                     }
                     if( resultNum > 1 ) {
-                        appendTooltipText( wrapper, "multiple pages using this", "Bug: Too many results", "small" );
+                        wrapper.append( '<span class="tooltip-title small" title="Bug: Too many results">multiple pages using this</span>' );
                     }
                 }
             }

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -314,35 +314,104 @@ function checkTidIntegration( tidPlayerUrl="", mdbPageId="", action="", wrapper=
 }
 
 var mdbTrackidTableBatchQueue = {},
-    mdbTrackidTableBatchTimer = null;
+    mdbTrackidTableBatchTimer = null,
+    mdbTrackidBatchMaxUrlsPerRequest = 25,
+    mdbTrackidBatchMaxQueryLength = 1800;
+
+function appendTooltipText( wrapper, text, title, extraClass="" ) {
+    var span = $("<span></span>")
+        .addClass( "tooltip-title" )
+        .attr( "title", title || "" )
+        .html( text );
+
+    if( extraClass ) {
+        span.addClass( extraClass );
+    }
+
+    wrapper.append( span );
+}
+
+function appendSafeCheckedLink( wrapper, checked_url ) {
+    try {
+        var checkedUrlObj = new URL( checked_url, window.location.origin );
+
+        if( !["http:", "https:"].includes( checkedUrlObj.protocol ) ) {
+            appendTooltipText( wrapper, "&ndash;", "MixesDB returned an unsupported link protocol" );
+            return;
+        }
+
+        var checkedLink = $("<a></a>")
+            .attr( "href", checkedUrlObj.href )
+            .append( $( checkIcon ) );
+
+        wrapper.append( checkedLink );
+    } catch( error ) {
+        appendTooltipText( wrapper, "&ndash;", "MixesDB returned an invalid link" );
+    }
+}
+
+function chunkTrackIdBatchPlayerUrls( playerUrls ) {
+    var chunks = [],
+        currentChunk = [],
+        currentLength = ( apiUrl_mw + "?action=mixesdbtrackidbatch&format=json" ).length;
+
+    $.each( playerUrls, function( index, playerUrl ) {
+        var queryPart = "&urls=" + encodeURIComponent( playerUrl );
+
+        if(
+            currentChunk.length > 0
+            && (
+                currentChunk.length >= mdbTrackidBatchMaxUrlsPerRequest
+                || currentLength + queryPart.length > mdbTrackidBatchMaxQueryLength
+            )
+        ) {
+            chunks.push( currentChunk );
+            currentChunk = [];
+            currentLength = ( apiUrl_mw + "?action=mixesdbtrackidbatch&format=json" ).length;
+        }
+
+        currentChunk.push( playerUrl );
+        currentLength += queryPart.length;
+    });
+
+    if( currentChunk.length > 0 ) {
+        chunks.push( currentChunk );
+    }
+
+    return chunks;
+}
 
 function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
     var currentUsername = $(".user-name").text(),
         allowUserTableMarking = ["Schrute_Inc.", "Komapatient"].includes(currentUsername),
-        dashText = '<span class="tooltip-title" title="Status is not ready">&ndash;</span>',
-        notYetIntegratedText = '<span class="tooltip-title small" title="This tracklist is not intergated yet to the found mix page">not yet</span>',
-        checked_pageId = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].page_id : "",
-        checked_url = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].url : "";
+        resultItems = Array.isArray( data.mixesdbtrackid ) ? data.mixesdbtrackid : [],
+        mixesdbPages = ( resultItems[0] && Array.isArray( resultItems[0].mixesdbpages ) ) ? resultItems[0].mixesdbpages : [],
+        firstMixesdbPage = mixesdbPages[0] || null,
+        checked_pageId = firstMixesdbPage ? firstMixesdbPage.page_id : "",
+        checked_url = firstMixesdbPage ? firstMixesdbPage.url : "";
 
     waiter = waiter || $("waiter", wrapper);
     waiter.remove();
 
     if( data.error && data.error.code == "notfound" ) {
-        wrapper.append( '<span class="tooltip-title" title="TrackId.net page not found (recently created?)">&ndash;</span>' );
+        appendTooltipText( wrapper, "&ndash;", "TrackId.net page not found (recently created?)" );
+        return;
+    }
+
+    if( data.error ) {
+        appendTooltipText( wrapper, "&ndash;", data.error.info || "TrackId.net batch check failed" );
         return;
     }
 
     if( checked_pageId ) {
-        var lastCheckedAgainstMixesDB = data.mixesdbtrackid[0].mixesdbpages[0].lastCheckedAgainstMixesDB;
+        var lastCheckedAgainstMixesDB = firstMixesdbPage.lastCheckedAgainstMixesDB;
 
         logVar( "lastCheckedAgainstMixesDB", lastCheckedAgainstMixesDB );
 
         if( lastCheckedAgainstMixesDB != null && lastCheckedAgainstMixesDB != "empty" ) {
             log( "Checked and page found: ("+checked_pageId+")" );
 
-            var checkedLink = '<a href="'+checked_url+'">'+checkIcon+'</a>';
-
-            wrapper.append( checkedLink );
+            appendSafeCheckedLink( wrapper, checked_url );
         } else {
             var status_td = wrapper.prev("td.status"),
                 status = $("div.MuiBox-root",status_td).attr("aria-label").trim();
@@ -354,10 +423,10 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
                     var input = make_mdbTrackidCheck_input( tidPlayerUrl, checked_pageId, "table" );
                     wrapper.append( input );
                 } else {
-                    wrapper.append( notYetIntegratedText );
+                    appendTooltipText( wrapper, "not yet", "This tracklist is not intergated yet to the found mix page", "small" );
                 }
             } else {
-                wrapper.append( dashText );
+                appendTooltipText( wrapper, "&ndash;", "Status is not ready" );
             }
         }
     } else {
@@ -388,22 +457,22 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
                                 var input = make_mdbTrackidCheck_input( tidPlayerUrl, mdbPageId, "table" );
                                 wrapper.append( input );
                             } else {
-                                wrapper.append( notYetIntegratedText );
+                                appendTooltipText( wrapper, "not yet", "This tracklist is not intergated yet to the found mix page", "small" );
                             }
                         } else {
-                            wrapper.append( dashText );
+                            appendTooltipText( wrapper, "&ndash;", "Status is not ready" );
                         }
                     } else {
-                        wrapper.append( notYetIntegratedText );
+                        appendTooltipText( wrapper, "not yet", "This tracklist is not intergated yet to the found mix page", "small" );
                     }
                 } else {
                     log( "resultNum != 1: " + resultNum );
 
                     if( resultNum == 0 ) {
-                        wrapper.append( '<span class="tooltip-title small" title="No MixesDB mix page found using this player">not found</span>' );
+                        appendTooltipText( wrapper, "not found", "No MixesDB mix page found using this player", "small" );
                     }
                     if( resultNum > 1 ) {
-                        wrapper.append( '<span class="tooltip-title small" title="Bug: Too many results">multiple pages using this</span>' );
+                        appendTooltipText( wrapper, "multiple pages using this", "Bug: Too many results", "small" );
                     }
                 }
             }
@@ -442,67 +511,75 @@ function flushTableTidIntegrationChecks() {
     mdbTrackidTableBatchQueue = {};
     mdbTrackidTableBatchTimer = null;
 
-    var apiQueryUrl = apiUrl_mw;
-    apiQueryUrl += "?action=mixesdbtrackidbatch";
-    apiQueryUrl += "&format=json";
+    $.each( chunkTrackIdBatchPlayerUrls( playerUrls ), function( chunkIndex, playerUrlChunk ) {
+        var apiQueryUrl = apiUrl_mw;
+        apiQueryUrl += "?action=mixesdbtrackidbatch";
+        apiQueryUrl += "&format=json";
 
-    $.each( playerUrls, function( index, playerUrl ) {
-        apiQueryUrl += "&urls=" + encodeURIComponent( playerUrl );
-    });
+        $.each( playerUrlChunk, function( index, playerUrl ) {
+            apiQueryUrl += "&urls=" + encodeURIComponent( playerUrl );
+        });
 
-    logVar( "apiQueryUrl_batch", apiQueryUrl );
+        logVar( "apiQueryUrl_batch", apiQueryUrl );
 
-    $.ajax({
-        url: apiQueryUrl,
-        type: 'get',
-        dataType: 'json',
-        async: true,
-        success: function(data) {
-            if( data.error ) {
-                $.each( playerUrls, function( index, playerUrl ) {
+        $.ajax({
+            url: apiQueryUrl,
+            type: 'get',
+            dataType: 'json',
+            async: true,
+            success: function(data) {
+                var resultsByUrl = {};
+
+                if( data.error ) {
+                    $.each( playerUrlChunk, function( index, playerUrl ) {
+                        $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
+                            renderTableTrackIdCheckResult( playerUrl, wrapper, { error: data.error }, $("waiter", wrapper) );
+                        });
+                    });
+                    return;
+                }
+
+                $.each( data.mixesdbtrackidbatch || [], function( index, result ) {
+                    if( result.requestedurl ) {
+                        resultsByUrl[result.requestedurl] = result;
+                    }
+                    if( result.sanitizedurl ) {
+                        resultsByUrl[result.sanitizedurl] = result;
+                    }
+                });
+
+                $.each( playerUrlChunk, function( index, playerUrl ) {
+                    var result = resultsByUrl[playerUrl] || {
+                            error: {
+                                code: "notfound",
+                                info: "No matching data found for the given URL",
+                                url: playerUrl
+                            }
+                        },
+                        tableData = {
+                            mixesdbtrackid: Array.isArray( result.mixesdbtrackid ) ? result.mixesdbtrackid : [],
+                            error: result.error
+                        };
+
                     $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
-                        renderTableTrackIdCheckResult( playerUrl, wrapper, { error: data.error }, $("waiter", wrapper) );
+                        renderTableTrackIdCheckResult( playerUrl, wrapper, tableData, $("waiter", wrapper) );
                     });
                 });
-                return;
+            },
+            error: function() {
+                $.each( playerUrlChunk, function( index, playerUrl ) {
+                    $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
+                        renderTableTrackIdCheckResult( playerUrl, wrapper, {
+                            error: {
+                                code: "batchfailed",
+                                info: "TrackId.net batch check failed",
+                                url: playerUrl
+                            }
+                        }, $("waiter", wrapper) );
+                    });
+                });
             }
-
-            var resultsByUrl = {};
-
-            $.each( data.mixesdbtrackidbatch || [], function( index, result ) {
-                resultsByUrl[result.requestedurl] = result;
-                if( result.sanitizedurl ) {
-                    resultsByUrl[result.sanitizedurl] = result;
-                }
-            });
-
-            $.each( playerUrls, function( index, playerUrl ) {
-                var result = resultsByUrl[playerUrl] || {
-                        error: {
-                            code: "notfound",
-                            info: "No matching data found for the given URL",
-                            url: playerUrl
-                        }
-                    },
-                    tableData = {
-                        mixesdbtrackid: result.mixesdbtrackid,
-                        error: result.error
-                    };
-
-                $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
-                    renderTableTrackIdCheckResult( playerUrl, wrapper, tableData, $("waiter", wrapper) );
-                });
-            });
-        },
-        error: function() {
-            $.each( playerUrls, function( index, playerUrl ) {
-                $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
-                    var waiter = $("waiter", wrapper);
-                    waiter.remove();
-                    wrapper.append( '<span class="tooltip-title" title="TrackId.net batch check failed">&ndash;</span>' );
-                });
-            });
-        }
+        });
     });
 }
 

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -222,9 +222,9 @@ function checkTidIntegration( tidPlayerUrl="", mdbPageId="", action="", wrapper=
         var apiQueryUrl_check = apiUrl_mw;
         apiQueryUrl_check += "?action=mixesdbtrackid";
         apiQueryUrl_check += "&format=json";
-        apiQueryUrl_check += "&url=" + tidPlayerUrl;
+        apiQueryUrl_check += "&url=" + encodeURIComponent( tidPlayerUrl );
 
-        var apiQueryUrl_save = apiQueryUrl_check + "&page_id=" + mdbPageId;
+        var apiQueryUrl_save = apiQueryUrl_check + "&page_id=" + encodeURIComponent( mdbPageId );
 
         // waiter
         if( target == "table" ) {
@@ -254,11 +254,14 @@ function checkTidIntegration( tidPlayerUrl="", mdbPageId="", action="", wrapper=
                             }
                         // if no error
                         } else {
-                            var checked_pageId = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].page_id : "",
-                                checked_url = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].url : "";
+                            var directResultItems = Array.isArray( data.mixesdbtrackid ) ? data.mixesdbtrackid : [],
+                                directMixesdbPages = ( directResultItems[0] && Array.isArray( directResultItems[0].mixesdbpages ) ) ? directResultItems[0].mixesdbpages : [],
+                                directFirstMixesdbPage = directMixesdbPages[0] || null,
+                                checked_pageId = directFirstMixesdbPage ? directFirstMixesdbPage.page_id : "",
+                                checked_url = directFirstMixesdbPage ? directFirstMixesdbPage.url : "";
 
                             if( checked_pageId == mdbPageId ) {
-                                var lastCheckedAgainstMixesDB = data.mixesdbtrackid[0].mixesdbpages[0].lastCheckedAgainstMixesDB;
+                                var lastCheckedAgainstMixesDB = directFirstMixesdbPage ? directFirstMixesdbPage.lastCheckedAgainstMixesDB : null;
 
                                 if( lastCheckedAgainstMixesDB != null ) {
                                     log( "Is marked as integrated (mdbPageId: " +mdbPageId+ ")" );
@@ -352,11 +355,18 @@ function appendSafeCheckedLink( wrapper, checked_url ) {
 
 function chunkTrackIdBatchPlayerUrls( playerUrls ) {
     var chunks = [],
+        oversizedUrls = [],
         currentChunk = [],
-        currentLength = ( apiUrl_mw + "?action=mixesdbtrackidbatch&format=json" ).length;
+        baseLength = ( apiUrl_mw + "?action=mixesdbtrackidbatch&format=json" ).length,
+        currentLength = baseLength;
 
     $.each( playerUrls, function( index, playerUrl ) {
         var queryPart = "&urls=" + encodeURIComponent( playerUrl );
+
+        if( baseLength + queryPart.length > mdbTrackidBatchMaxQueryLength ) {
+            oversizedUrls.push( playerUrl );
+            return;
+        }
 
         if(
             currentChunk.length > 0
@@ -367,7 +377,7 @@ function chunkTrackIdBatchPlayerUrls( playerUrls ) {
         ) {
             chunks.push( currentChunk );
             currentChunk = [];
-            currentLength = ( apiUrl_mw + "?action=mixesdbtrackidbatch&format=json" ).length;
+            currentLength = baseLength;
         }
 
         currentChunk.push( playerUrl );
@@ -378,7 +388,10 @@ function chunkTrackIdBatchPlayerUrls( playerUrls ) {
         chunks.push( currentChunk );
     }
 
-    return chunks;
+    return {
+        chunks: chunks,
+        oversizedUrls: oversizedUrls
+    };
 }
 
 function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter ) {
@@ -511,7 +524,21 @@ function flushTableTidIntegrationChecks() {
     mdbTrackidTableBatchQueue = {};
     mdbTrackidTableBatchTimer = null;
 
-    $.each( chunkTrackIdBatchPlayerUrls( playerUrls ), function( chunkIndex, playerUrlChunk ) {
+    var batchPlan = chunkTrackIdBatchPlayerUrls( playerUrls );
+
+    $.each( batchPlan.oversizedUrls, function( index, playerUrl ) {
+        $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
+            renderTableTrackIdCheckResult( playerUrl, wrapper, {
+                error: {
+                    code: "batchtoolong",
+                    info: "TrackId.net player URL is too long for batch checking",
+                    url: playerUrl
+                }
+            }, $("waiter", wrapper) );
+        });
+    });
+
+    $.each( batchPlan.chunks, function( chunkIndex, playerUrlChunk ) {
         var apiQueryUrl = apiUrl_mw;
         apiQueryUrl += "?action=mixesdbtrackidbatch";
         apiQueryUrl += "&format=json";
@@ -549,16 +576,12 @@ function flushTableTidIntegrationChecks() {
                 });
 
                 $.each( playerUrlChunk, function( index, playerUrl ) {
-                    var result = resultsByUrl[playerUrl] || {
-                            error: {
-                                code: "notfound",
-                                info: "No matching data found for the given URL",
-                                url: playerUrl
-                            }
-                        },
-                        tableData = {
+                    var result = resultsByUrl[playerUrl],
+                        tableData = result ? {
                             mixesdbtrackid: Array.isArray( result.mixesdbtrackid ) ? result.mixesdbtrackid : [],
                             error: result.error
+                        } : {
+                            mixesdbtrackid: []
                         };
 
                     $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {

--- a/includes/toolkit.js
+++ b/includes/toolkit.js
@@ -422,7 +422,7 @@ function apiUrl_searchKeywords_fromUrl( thisUrl ) {
 
     var keywords = mixesdbPlayerUsage_keywords( thisUrl );
 
-    return 'https://www.mixesdb.com/w/api.php?action=mixesdb_player_search&format=json&url='+keywords;
+    return 'https://www.mixesdb.com/w/api.php?action=mixesdb_player_search&format=json&url='+encodeURIComponent( keywords );
 }
 
 // makeAvailableLinksListItem

--- a/includes/toolkit.js
+++ b/includes/toolkit.js
@@ -422,7 +422,7 @@ function apiUrl_searchKeywords_fromUrl( thisUrl ) {
 
     var keywords = mixesdbPlayerUsage_keywords( thisUrl );
 
-    return 'https://www.mixesdb.com/w/api.php?action=mixesdb_player_search&format=json&url='+encodeURIComponent( keywords );
+    return 'https://www.mixesdb.com/w/api.php?action=mixesdb_player_search&format=json&url='+keywords;
 }
 
 // makeAvailableLinksListItem


### PR DESCRIPTION
## Summary
- batch `.mdb-tid-table` MixesDB integration lookups through `action=mixesdbtrackidbatch`
- keep the existing single-page and save flows on `mixesdbtrackid`
- extract the table rendering logic into a shared helper so batched responses map back onto each cell

## Test Plan
- `node --check TrackId.net/script.user.js`
- `git diff --check`
- confirmed live MixesDB production now serves `action=mixesdbtrackidbatch`

## Context
This reduces the per-row request fan-out from the TrackId.net userscript that was driving the recent MixesDB request spike.
