### PR TITLE
Batch Explorer TrackId checks

### DIFF
--- a/MixesDB_Userscripts_Helper/script.user.js
+++ b/MixesDB_Userscripts_Helper/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MixesDB Userscripts Helper (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.13.2
+// @version      2026.05.13.3
 // @description  Change the look and behaviour of the MixesDB website to enable feature usable by other MixesDB userscripts.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1293952534268084234
@@ -69,7 +69,9 @@ const applePodcasts_addSearchIcons = 1; // default: 1
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 var cacheVersion = 11,
-    scriptName = "MixesDB_Userscripts_Helper";
+    scriptName = "MixesDB_Userscripts_Helper",
+    mdbTrackidBatchMaxUrlsPerRequest = 25,
+    mdbTrackidBatchMaxQueryLength = 1800;
 
 //loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
 loadRawCss( githubPath_raw + scriptName + "/script.css?v-" + cacheVersion );
@@ -109,6 +111,182 @@ function getApplePodcastsSearchLink( className, keywords ) {
     return iconLink;
 }
 
+function normalizeTrackIdPlayerUrl( playerSite, playerUrl ) {
+    if( !playerUrl ) {
+        return "";
+    }
+
+    // Remove URL parameters from e.g. SoundCloud and Mixcloud
+    if( playerSite != "YouTube" ) {
+        playerUrl = removeParametersFromUrl( playerUrl );
+    } else {
+        playerUrl = playerUrl.replace( "www.youtu.be", "youtu.be" );
+    }
+
+    if( playerSite == "hearthis-at" ) {
+        playerUrl = playerUrl.replace( "hearthis.audio", "hearthis.at" );
+    }
+
+    return playerUrl;
+}
+
+function buildTrackIdBatchQueryValue( playerUrls ) {
+    return encodeURIComponent( playerUrls.join( "|" ) );
+}
+
+function chunkTrackIdBatchPlayerUrls( playerUrls ) {
+    var chunks = [],
+        oversizedUrls = [],
+        currentChunk = [],
+        baseLength = ( apiUrl_mw + "?action=mixesdbtrackidbatch&format=json&urls=" ).length;
+
+    $.each( playerUrls, function( index, playerUrl ) {
+        var singleUrlLength = baseLength + buildTrackIdBatchQueryValue( [ playerUrl ] ).length,
+            nextChunk = currentChunk.concat( [ playerUrl ] ),
+            nextChunkLength = baseLength + buildTrackIdBatchQueryValue( nextChunk ).length;
+
+        if( singleUrlLength > mdbTrackidBatchMaxQueryLength ) {
+            oversizedUrls.push( playerUrl );
+            return;
+        }
+
+        if(
+            currentChunk.length > 0
+            && (
+                currentChunk.length >= mdbTrackidBatchMaxUrlsPerRequest
+                || nextChunkLength > mdbTrackidBatchMaxQueryLength
+            )
+        ) {
+            chunks.push( currentChunk );
+            currentChunk = [ playerUrl ];
+            return;
+        }
+
+        currentChunk = nextChunk;
+    });
+
+    if( currentChunk.length > 0 ) {
+        chunks.push( currentChunk );
+    }
+
+    return {
+        chunks: chunks,
+        oversizedUrls: oversizedUrls
+    };
+}
+
+function groupExplorerTrackIdEntriesByUrl( entries ) {
+    var groupedEntries = {};
+
+    $.each( entries, function( index, entry ) {
+        if( !groupedEntries[entry.playerUrl] ) {
+            groupedEntries[entry.playerUrl] = [];
+        }
+
+        groupedEntries[entry.playerUrl].push( entry );
+    });
+
+    return groupedEntries;
+}
+
+function indexTrackIdBatchResultsByUrl( batchResults ) {
+    var resultsByUrl = {};
+
+    $.each( batchResults || [], function( index, result ) {
+        if( result.requestedurl ) {
+            resultsByUrl[result.requestedurl] = result;
+        }
+        if( result.sanitizedurl ) {
+            resultsByUrl[result.sanitizedurl] = result;
+        }
+    });
+
+    return resultsByUrl;
+}
+
+function renderExplorerTrackIdEntry( entry, result ) {
+    var playerWrapper = entry.playerWrapper,
+        playerSite = entry.playerSite,
+        playerUrl = entry.playerUrl,
+        keywords = entry.keywords;
+
+    if( result && !( result.error && result.error.code == "notfound" ) ) {
+        var tidLink = "",
+            trackidurl = result.mixesdbtrackid?.[0]?.trackidurl || null,
+            lastCheckedAgainstMixesDB = result.mixesdbtrackid?.[0]?.mixesdbpages?.[0]?.lastCheckedAgainstMixesDB || null;
+
+        logVar( "trackidurl", trackidurl );
+        logVar( "lastCheckedAgainstMixesDB", lastCheckedAgainstMixesDB );
+
+        if( trackidurl ) {
+            tidLink += '<a href="'+trackidurl+'">Exists on TrackId.net</a>';
+
+            if( lastCheckedAgainstMixesDB ) {
+                tidLink += ' <span id="mdbTrackidCheck-wrapper" class="integrated" style="max-height:15px">'+checkIcon+'integrated</span>';
+                tidLink += ' ' + toolkit_tidLastCheckedText( lastCheckedAgainstMixesDB );
+            } else {
+                tidLink += ' (not integrated yet)';
+            }
+        }
+
+        if( tidLink != "" ) {
+            playerWrapper.append( '<div class="tidLink '+playerSite+' grey">'+tidLink+'</div>' );
+            return;
+        }
+    }
+
+    var tidLink_submit = '<a href="'+makeTidSubmitUrl( playerUrl, keywords )+'" target="_blank">Submit to TrackId.net</a>';
+    playerWrapper.append( '<div class="tidLink '+playerSite+'">'+tidLink_submit+'</div>' );
+}
+
+function runExplorerTrackIdBatchChecks( entries ) {
+    if( entries.length === 0 ) {
+        return;
+    }
+
+    var groupedEntries = groupExplorerTrackIdEntriesByUrl( entries ),
+        playerUrls = Object.keys( groupedEntries ),
+        batchPlan = chunkTrackIdBatchPlayerUrls( playerUrls );
+
+    $.each( batchPlan.oversizedUrls, function( index, playerUrl ) {
+        $.each( groupedEntries[playerUrl] || [], function( entryIndex, entry ) {
+            renderExplorerTrackIdEntry( entry, null );
+        });
+    });
+
+    $.each( batchPlan.chunks, function( chunkIndex, playerUrlChunk ) {
+        var apiQueryUrl = apiUrl_mw;
+        apiQueryUrl += "?action=mixesdbtrackidbatch";
+        apiQueryUrl += "&format=json";
+        apiQueryUrl += "&urls=" + buildTrackIdBatchQueryValue( playerUrlChunk );
+
+        logVar( "apiQueryUrl_batch", apiQueryUrl );
+
+        $.ajax({
+            url: apiQueryUrl,
+            type: 'get',
+            dataType: 'json',
+            async: true,
+            success: function(data) {
+                var resultsByUrl = indexTrackIdBatchResultsByUrl( data.mixesdbtrackidbatch || [] );
+
+                $.each( playerUrlChunk, function( index, playerUrl ) {
+                    $.each( groupedEntries[playerUrl] || [], function( entryIndex, entry ) {
+                        renderExplorerTrackIdEntry( entry, resultsByUrl[playerUrl] || null );
+                    });
+                });
+            },
+            error: function() {
+                $.each( playerUrlChunk, function( index, playerUrl ) {
+                    $.each( groupedEntries[playerUrl] || [], function( entryIndex, entry ) {
+                        renderExplorerTrackIdEntry( entry, null );
+                    });
+                });
+            }
+        });
+    });
+}
+
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *
@@ -132,34 +310,28 @@ d.ready(function(){ // needed for mw.config
      * Also allow on page edit (preview)
      */
     if( trackIdnet_addLinks
-        && ( wgNamespaceNumber==0 && wgTitle!="Main Page" )
-        || ( wgNamespaceNumber==4 && wgPageName=="MixesDB:Explorer/Mixes" )
+        && ( ( wgNamespaceNumber==0 && wgTitle!="Main Page" )
+        || ( wgNamespaceNumber==4 && wgPageName=="MixesDB:Explorer/Mixes" ) )
       ) {
         log( "Criteria for mix page matched." );
 
         /*
          * TrackId.net submit link under each player
          */
+        var explorerTrackIdEntries = [];
+
         $(".playerWrapper[data-playersite]").each(function(){
             var playerWrapper = $(this),
                 playerTidCompatible = playerWrapper.attr("data-tidcompatibleplayersite"),
                 playerUrl = playerWrapper.attr("data-playerurl"),
                 playerSite = makeCssSafe( playerWrapper.attr("data-playersite") ),
-                keywords = "";
+                keywords = "",
+                isExplorerPage = ( wgNamespaceNumber==4 && wgPageName=="MixesDB:Explorer/Mixes" );
 
             logVar( "playerSite", playerSite );
             logVar( "playerUrl", playerUrl );
 
-            // Remove URL paramteres from e.g. SoundCloud and Mixcloud
-            if( playerSite != "YouTube" ) {
-                playerUrl = removeParametersFromUrl( playerWrapper.attr("data-playerurl") );
-            } else {
-                playerUrl = playerUrl.replace( "www.youtu.be", "youtu.be" );
-            }
-
-            if( playerSite == "hearthis-at" ) {
-                playerUrl = playerUrl.replace( "hearthis.audio", "hearthis.at" );
-            }
+            playerUrl = normalizeTrackIdPlayerUrl( playerSite, playerUrl );
 
             // if mix page
             if( wgNamespaceNumber==0 && wgTitle!="Main Page" ) {
@@ -167,13 +339,22 @@ d.ready(function(){ // needed for mw.config
             }
 
             // if Explorer/Mixes
-            if( wgNamespaceNumber==4 && wgPageName=="MixesDB:Explorer/Mixes" ) {
+            if( isExplorerPage ) {
                 var explorerResult = playerWrapper.closest(".explorerResult"),
                     explorerResult_title = $(".playerLink", explorerResult).attr("title");
                 keywords = normalizeTitleForSearch( explorerResult_title );
             }
 
             if( playerTidCompatible == "true" ) {
+                if( isExplorerPage ) {
+                    explorerTrackIdEntries.push({
+                        playerWrapper: playerWrapper,
+                        playerSite: playerSite,
+                        playerUrl: playerUrl,
+                        keywords: keywords
+                    });
+                    return;
+                }
 
                 // check usage
                 var apiQueryUrl_check = apiUrl_mw;
@@ -223,6 +404,10 @@ d.ready(function(){ // needed for mw.config
                 log( "NOT playerTidCompatible: " + playerUrl );
             }
         });
+
+        if( explorerTrackIdEntries.length > 0 ) {
+            runExplorerTrackIdBatchChecks( explorerTrackIdEntries );
+        }
     }
 
     /*

--- a/tests/issue-686-explorer-batch.test.mjs
+++ b/tests/issue-686-explorer-batch.test.mjs
@@ -1,0 +1,159 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const scriptPath = new URL('../MixesDB_Userscripts_Helper/script.user.js', import.meta.url);
+const scriptSource = fs.readFileSync(scriptPath, 'utf8');
+
+function extractFunction(name) {
+  const start = scriptSource.indexOf(`function ${name}(`);
+  if (start === -1) {
+    throw new Error(`Could not find function ${name}`);
+  }
+
+  let depth = 0;
+  let end = -1;
+  let seenBrace = false;
+
+  for (let i = start; i < scriptSource.length; i += 1) {
+    const char = scriptSource[i];
+    if (char === '{') {
+      depth += 1;
+      seenBrace = true;
+    } else if (char === '}') {
+      depth -= 1;
+      if (seenBrace && depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+
+  if (end === -1) {
+    throw new Error(`Could not parse function ${name}`);
+  }
+
+  return scriptSource.slice(start, end);
+}
+
+function loadFunctions(names, overrides = {}) {
+  const context = {
+    apiUrl_mw: 'https://www.mixesdb.com/w/api.php',
+    encodeURIComponent,
+    mdbTrackidBatchMaxQueryLength: 1800,
+    mdbTrackidBatchMaxUrlsPerRequest: 25,
+    removeParametersFromUrl(url) {
+      return url.replace(/\?.*$/, '');
+    },
+    $: {
+      each(collection, callback) {
+        if (Array.isArray(collection)) {
+          collection.forEach((value, index) => callback(index, value));
+          return;
+        }
+
+        Object.keys(collection).forEach((key) => callback(key, collection[key]));
+      },
+    },
+    ...overrides,
+  };
+
+  vm.createContext(context);
+  for (const name of names) {
+    vm.runInContext(extractFunction(name), context);
+  }
+  return context;
+}
+
+test('normalizeTrackIdPlayerUrl keeps explorer batch URLs aligned with existing single-check normalization', () => {
+  const { normalizeTrackIdPlayerUrl } = loadFunctions(['normalizeTrackIdPlayerUrl']);
+
+  assert.equal(
+    normalizeTrackIdPlayerUrl('SoundCloud', 'https://soundcloud.com/artist/mix?si=abc123'),
+    'https://soundcloud.com/artist/mix'
+  );
+  assert.equal(
+    normalizeTrackIdPlayerUrl('YouTube', 'https://www.youtu.be/example123'),
+    'https://youtu.be/example123'
+  );
+  assert.equal(
+    normalizeTrackIdPlayerUrl('hearthis-at', 'https://hearthis.audio/artist/show?utm_source=test'),
+    'https://hearthis.at/artist/show'
+  );
+});
+
+test('chunkTrackIdBatchPlayerUrls respects both URL-count and query-length limits', () => {
+  const countLimitedContext = loadFunctions(
+    ['buildTrackIdBatchQueryValue', 'chunkTrackIdBatchPlayerUrls'],
+    {
+      mdbTrackidBatchMaxUrlsPerRequest: 2,
+      mdbTrackidBatchMaxQueryLength: 9999,
+    }
+  );
+
+  const countLimitedPlan = countLimitedContext.chunkTrackIdBatchPlayerUrls([
+    'https://e.co/a',
+    'https://e.co/b',
+    'https://e.co/c',
+  ]);
+
+  const normalizedChunks = JSON.parse(JSON.stringify(countLimitedPlan.chunks));
+
+  assert.deepEqual(
+    normalizedChunks,
+    [
+      ['https://e.co/a', 'https://e.co/b'],
+      ['https://e.co/c'],
+    ]
+  );
+
+  const lengthLimitedContext = loadFunctions(
+    ['buildTrackIdBatchQueryValue', 'chunkTrackIdBatchPlayerUrls'],
+    {
+      mdbTrackidBatchMaxUrlsPerRequest: 25,
+      mdbTrackidBatchMaxQueryLength: 90,
+    }
+  );
+
+  const lengthLimitedPlan = lengthLimitedContext.chunkTrackIdBatchPlayerUrls([
+    'https://example.com/this-url-is-deliberately-too-long-for-the-query-limit',
+  ]);
+
+  assert.deepEqual(Array.from(lengthLimitedPlan.chunks), []);
+  assert.deepEqual(
+    Array.from(lengthLimitedPlan.oversizedUrls),
+    ['https://example.com/this-url-is-deliberately-too-long-for-the-query-limit']
+  );
+});
+
+test('groupExplorerTrackIdEntriesByUrl dedupes repeated player URLs before request dispatch', () => {
+  const { groupExplorerTrackIdEntriesByUrl } = loadFunctions(['groupExplorerTrackIdEntriesByUrl']);
+
+  const grouped = groupExplorerTrackIdEntriesByUrl([
+    { playerUrl: 'https://example.com/a', id: 'row-1' },
+    { playerUrl: 'https://example.com/a', id: 'row-2' },
+    { playerUrl: 'https://example.com/b', id: 'row-3' },
+  ]);
+
+  assert.deepEqual(Object.keys(grouped).sort(), ['https://example.com/a', 'https://example.com/b']);
+  assert.deepEqual(
+    Array.from(grouped['https://example.com/a'], (entry) => entry.id),
+    ['row-1', 'row-2']
+  );
+});
+
+test('indexTrackIdBatchResultsByUrl maps both requested and sanitized URLs to the shared batch result', () => {
+  const { indexTrackIdBatchResultsByUrl } = loadFunctions(['indexTrackIdBatchResultsByUrl']);
+
+  const result = {
+    requestedurl: 'https://example.com/raw?utm_source=abc',
+    sanitizedurl: 'https://example.com/raw',
+    mixesdbtrackid: [{ trackidurl: 'https://trackid.net/a' }],
+  };
+
+  const index = indexTrackIdBatchResultsByUrl([result]);
+
+  assert.equal(index['https://example.com/raw?utm_source=abc'], result);
+  assert.equal(index['https://example.com/raw'], result);
+});


### PR DESCRIPTION
Fixes #686.\n\n## Summary\n- Batch TrackId checks on MixesDB:Explorer/Mixes instead of issuing one request per row\n- Deduplicate repeated player URLs before dispatch\n- Keep per-row single-check flow on normal mix pages\n- Preserve submit-link fallback without refanning into single API calls after a batch miss\n\n## Validation\n- node --check MixesDB_Userscripts_Helper/script.user.js\n- node --check tests/issue-686-explorer-batch.test.mjs\n- node --test tests/issue-686-explorer-batch.test.mjs\n- git diff --check