### PR TITLE
Share TrackId request dedupe across helper/toolkit/TrackId flows

### DIFF
--- a/MixesDB_Userscripts_Helper/script.user.js
+++ b/MixesDB_Userscripts_Helper/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MixesDB Userscripts Helper (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.13.2
+// @version      2026.05.22.1
 // @description  Change the look and behaviour of the MixesDB website to enable feature usable by other MixesDB userscripts.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1293952534268084234
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-MixesDB_Userscripts_Helper_13
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-MixesDB_Userscripts_Helper_5
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-MixesDB_Userscripts_Helper_6
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
 // @noframes
@@ -175,50 +175,38 @@ d.ready(function(){ // needed for mw.config
 
             if( playerTidCompatible == "true" ) {
 
-                // check usage
-                var apiQueryUrl_check = apiUrl_mw;
-                apiQueryUrl_check += "?action=mixesdbtrackid";
-                apiQueryUrl_check += "&format=json";
-                apiQueryUrl_check += "&url=" + playerUrl;
+                toolkit_requestTrackIdLookup( playerUrl, {
+                    source: "helper"
+                } ).done(function( data ) {
+                    // avoid undefined error
+                    if( ( data.error && data.error.code == "notfound" )  ) {
+                        // no result
+                        var tidLink_submit = '<a href="'+makeTidSubmitUrl( playerUrl, keywords )+'" target="_blank">Submit to TrackId.net</a>';
+                        playerWrapper.append( '<div class="tidLink '+playerSite+'">'+tidLink_submit+'</div>' );
+                    } else {
+                        var tidLink = "",
+                            trackidurl = data.mixesdbtrackid?.[0]?.trackidurl || null,
+                            lastCheckedAgainstMixesDB = data.mixesdbtrackid?.[0]?.mixesdbpages?.[0]?.lastCheckedAgainstMixesDB || null;
 
-                logVar( "apiQueryUrl_check", apiQueryUrl_check );
+                        logVar( "trackidurl", trackidurl );
+                        logVar( "lastCheckedAgainstMixesDB", lastCheckedAgainstMixesDB );
 
-                $.ajax({
-                    url: apiQueryUrl_check,
-                    type: 'get', /* GET on checking */
-                    dataType: 'json',
-                    async: true,
-                    success: function(data) {
-                        // avoid undefined error
-                        if( ( data.error && data.error.code == "notfound" )  ) {
-                            // no result
-                            var tidLink_submit = '<a href="'+makeTidSubmitUrl( playerUrl, keywords )+'" target="_blank">Submit to TrackId.net</a>';
-                            playerWrapper.append( '<div class="tidLink '+playerSite+'">'+tidLink_submit+'</div>' );
-                        } else {
-                            var tidLink = "",
-                                trackidurl = data.mixesdbtrackid?.[0]?.trackidurl || null,
-                                lastCheckedAgainstMixesDB = data.mixesdbtrackid?.[0]?.mixesdbpages?.[0]?.lastCheckedAgainstMixesDB || null;
+                        if( trackidurl ) {
+                            tidLink += '<a href="'+trackidurl+'">Exists on TrackId.net</a>';
 
-                            logVar( "trackidurl", trackidurl );
-                            logVar( "lastCheckedAgainstMixesDB", lastCheckedAgainstMixesDB );
-
-                            if( trackidurl ) {
-                                tidLink += '<a href="'+trackidurl+'">Exists on TrackId.net</a>';
-
-                                if( lastCheckedAgainstMixesDB ) {
-                                    tidLink += ' <span id="mdbTrackidCheck-wrapper" class="integrated" style="max-height:15px">'+checkIcon+'integrated</span>';
-                                    tidLink += ' ' + toolkit_tidLastCheckedText( lastCheckedAgainstMixesDB );
-                                } else {
-                                    tidLink += ' (not integrated yet)';
-                                }
-                            }
-
-                            if( tidLink != "" ) {
-                                playerWrapper.append( '<div class="tidLink '+playerSite+' grey">'+tidLink+'</div>' );
+                            if( lastCheckedAgainstMixesDB ) {
+                                tidLink += ' <span id="mdbTrackidCheck-wrapper" class="integrated" style="max-height:15px">'+checkIcon+'integrated</span>';
+                                tidLink += ' ' + toolkit_tidLastCheckedText( lastCheckedAgainstMixesDB );
+                            } else {
+                                tidLink += ' (not integrated yet)';
                             }
                         }
+
+                        if( tidLink != "" ) {
+                            playerWrapper.append( '<div class="tidLink '+playerSite+' grey">'+tidLink+'</div>' );
+                        }
                     }
-                }); // END ajax
+                });
             } else {
                 log( "NOT playerTidCompatible: " + playerUrl );
             }

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TrackId.net (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.19.1
+// @version      2026.05.22.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -11,7 +11,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/youtube_funcs.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-TrackId.net_109
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-TrackId.net_85
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-TrackId.net_86
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Tracklist_Cue_Switcher/script.funcs.js?v_2
 // @include      http*trackid.net*
 // @include      http*mixesdb.com/w/*
@@ -219,12 +219,7 @@ function checkTidIntegration( tidPlayerUrl="", mdbPageId="", action="", wrapper=
     logVar( "wrapper", wrapper.html() );
 
     if( tidPlayerUrl && tidPlayerUrl != "" && typeof(tidPlayerUrl) !== "undefined" && tidPlayerUrl != "undefined" ) {
-        var apiQueryUrl_check = apiUrl_mw;
-        apiQueryUrl_check += "?action=mixesdbtrackid";
-        apiQueryUrl_check += "&format=json";
-        apiQueryUrl_check += "&url=" + tidPlayerUrl;
-
-        var apiQueryUrl_save = apiQueryUrl_check + "&page_id=" + mdbPageId;
+        var apiQueryUrl_save = apiUrl_mw + "?action=mixesdbtrackid&format=json&url=" + encodeURIComponent( normalizeTrackIdLookupUrl( tidPlayerUrl ) ) + "&page_id=" + encodeURIComponent( mdbPageId );
 
         // waiter
         if( target == "table" ) {
@@ -235,59 +230,53 @@ function checkTidIntegration( tidPlayerUrl="", mdbPageId="", action="", wrapper=
         switch( action ) {
             // check
             case "check":
-                logVar( "apiQueryUrl_check", apiQueryUrl_check );
+                toolkit_requestTrackIdLookup( tidPlayerUrl, {
+                    source: "TrackId.check"
+                } ).done(function( data ) {
+                    // avoid undefined error
+                    if( data.error && data.error.code == "notfound" ) {
+                        if( target == "audiostream page" ) {
+                            wrapper.html('Marking this as integrated is not possible yet.').show();
+                        }
+                        if( target == "table" ) {
+                            waiter.remove();
+                            wrapper.append( '<span class="tooltip-title" title="TrackId.net page not found (recently created?)">&ndash;</span>' );
+                        }
+                    // if no error
+                    } else {
+                        var checked_pageId = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].page_id : "",
+                            checked_url = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].url : "";
 
-                $.ajax({
-                    url: apiQueryUrl_check,
-                    type: 'get', /* GET on checking */
-                    dataType: 'json',
-                    async: true,
-                    success: function(data) {
-                        // avoid undefined error
-                        if( data.error && data.error.code == "notfound" ) {
-                            if( target == "audiostream page" ) {
-                                wrapper.html('Marking this as integrated is not possible yet.').show();
-                            }
-                            if( target == "table" ) {
-                                waiter.remove();
-                                wrapper.append( '<span class="tooltip-title" title="TrackId.net page not found (recently created?)">&ndash;</span>' );
-                            }
-                        // if no error
-                        } else {
-                            var checked_pageId = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].page_id : "",
-                                checked_url = ( data.mixesdbtrackid && data.mixesdbtrackid[0].mixesdbpages[0] ) ? data.mixesdbtrackid[0].mixesdbpages[0].url : "";
+                        if( checked_pageId == mdbPageId ) {
+                            var lastCheckedAgainstMixesDB = data.mixesdbtrackid[0].mixesdbpages[0].lastCheckedAgainstMixesDB;
 
-                            if( checked_pageId == mdbPageId ) {
-                                var lastCheckedAgainstMixesDB = data.mixesdbtrackid[0].mixesdbpages[0].lastCheckedAgainstMixesDB;
+                            if( lastCheckedAgainstMixesDB != null ) {
+                                log( "Is marked as integrated (mdbPageId: " +mdbPageId+ ")" );
+                                $("input", wrapper).replaceWith(checkIcon);
 
-                                if( lastCheckedAgainstMixesDB != null ) {
-                                    log( "Is marked as integrated (mdbPageId: " +mdbPageId+ ")" );
-                                    $("input", wrapper).replaceWith(checkIcon);
+                                var checked_ago_text = toolkit_tidLastCheckedText( lastCheckedAgainstMixesDB );
 
-                                    var checked_ago_text = toolkit_tidLastCheckedText( lastCheckedAgainstMixesDB );
+                                if( checked_ago_text ) $("label", wrapper).next("span.mdb-tooltip").replaceWith( checked_ago_text );
 
-                                    if( checked_ago_text ) $("label", wrapper).next("span.mdb-tooltip").replaceWith( checked_ago_text );
-
-                                    /* show */
-                                    wrapper.addClass("integrated").show();
-                                } else {
-                                    wrapper.show();
-                                }
-
+                                /* show */
+                                wrapper.addClass("integrated").show();
                             } else {
-                                // audiostream page
-                                if( target == "audiostream page" ) {
-                                    log( "Not saved as integrated (mdbPageId: " +mdbPageId+ ")" );
+                                wrapper.show();
+                            }
 
-                                    $("input", wrapper).removeAttr("checked").prop('checked', false);
+                        } else {
+                            // audiostream page
+                            if( target == "audiostream page" ) {
+                                log( "Not saved as integrated (mdbPageId: " +mdbPageId+ ")" );
 
-                                    wrapper.show();
-                                }
+                                $("input", wrapper).removeAttr("checked").prop('checked', false);
 
-                                // tables
-                                if( target == "table" ) {
-                                    renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter );
-                                }
+                                wrapper.show();
+                            }
+
+                            // tables
+                            if( target == "table" ) {
+                                renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter );
                             }
                         }
                     }
@@ -483,9 +472,9 @@ function renderTableTrackIdCheckResult( tidPlayerUrl, wrapper, data, waiter, opt
 }
 
 function queueTableTidIntegrationCheck( wrapper ) {
-    var playerUrl = wrapper.attr("data-tidplayerurl");
+    var playerUrl = normalizeTrackIdLookupUrl( wrapper.attr("data-tidplayerurl") );
 
-    if( !playerUrl || playerUrl == "undefined" ) {
+    if( !playerUrl ) {
         return;
     }
 
@@ -533,72 +522,41 @@ function flushTableTidIntegrationChecks() {
     });
 
     $.each( batchPlan.chunks, function( chunkIndex, playerUrlChunk ) {
-        var apiQueryUrl = apiUrl_mw;
-        apiQueryUrl += "?action=mixesdbtrackidbatch";
-        apiQueryUrl += "&format=json";
-        apiQueryUrl += "&urls=" + buildTrackIdBatchQueryValue( playerUrlChunk );
+        toolkit_requestTrackIdBatchLookup( playerUrlChunk, {
+            source: "TrackId.batch"
+        } ).done(function( resultsByUrl ) {
+            $.each( playerUrlChunk, function( index, playerUrl ) {
+                var result = resultsByUrl[playerUrl],
+                    tableData = result ? ( result.__trackidBatchMiss ? {
+                        // No direct batch hit: fall through to the existing search-keyword path
+                        // instead of inventing a new table-only row state.
+                        mixesdbtrackid: []
+                    } : {
+                        mixesdbtrackid: Array.isArray( result.mixesdbtrackid ) ? result.mixesdbtrackid : [],
+                        error: result.error
+                    } ) : {
+                        mixesdbtrackid: []
+                    },
+                    renderOptions = result && result.__trackidBatchMiss ? {} : {
+                        skipSearchFallback: true
+                    };
 
-        logVar( "apiQueryUrl_batch", apiQueryUrl );
-
-        $.ajax({
-            url: apiQueryUrl,
-            type: 'get',
-            dataType: 'json',
-            async: true,
-            success: function(data) {
-                var resultsByUrl = {};
-
-                if( data.error ) {
-                    $.each( playerUrlChunk, function( index, playerUrl ) {
-                        $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
-                            renderTableTrackIdCheckResult( playerUrl, wrapper, { error: data.error }, $("waiter", wrapper) );
-                        });
-                    });
-                    return;
-                }
-
-                $.each( data.mixesdbtrackidbatch || [], function( index, result ) {
-                    // The batch API echoes both requestedurl and sanitizedurl.
-                    // Index both so the table lookup can tolerate backend normalization.
-                    if( result.requestedurl ) {
-                        resultsByUrl[result.requestedurl] = result;
-                    }
-                    if( result.sanitizedurl ) {
-                        resultsByUrl[result.sanitizedurl] = result;
-                    }
+                $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
+                    renderTableTrackIdCheckResult( playerUrl, wrapper, tableData, $("waiter", wrapper), renderOptions );
                 });
-
-                $.each( playerUrlChunk, function( index, playerUrl ) {
-                    var result = resultsByUrl[playerUrl],
-                        tableData = result ? {
-                            mixesdbtrackid: Array.isArray( result.mixesdbtrackid ) ? result.mixesdbtrackid : [],
-                            error: result.error
-                        } : {
-                            // No direct batch hit: fall through to the existing search-keyword path
-                            // instead of inventing a new table-only row state.
-                            mixesdbtrackid: []
-                        };
-
-                    $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
-                        renderTableTrackIdCheckResult( playerUrl, wrapper, tableData, $("waiter", wrapper), {
-                            skipSearchFallback: true
-                        } );
-                    });
+            });
+        }).fail(function( error ) {
+            $.each( playerUrlChunk, function( index, playerUrl ) {
+                $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
+                    renderTableTrackIdCheckResult( playerUrl, wrapper, {
+                        error: {
+                            code: "batchfailed",
+                            info: error && error.info ? error.info : "TrackId.net batch check failed",
+                            url: playerUrl
+                        }
+                    }, $("waiter", wrapper) );
                 });
-            },
-            error: function() {
-                $.each( playerUrlChunk, function( index, playerUrl ) {
-                    $.each( queue[playerUrl] || [], function( wrapperIndex, wrapper ) {
-                        renderTableTrackIdCheckResult( playerUrl, wrapper, {
-                            error: {
-                                code: "batchfailed",
-                                info: "TrackId.net batch check failed",
-                                url: playerUrl
-                            }
-                        }, $("waiter", wrapper) );
-                    });
-                });
-            }
+            });
         });
     });
 }

--- a/includes/toolkit.js
+++ b/includes/toolkit.js
@@ -24,6 +24,304 @@ function changeYoutubeUrlVariant(url, variant = "youtube.com") {
     }
 }
 
+var mdbTrackidLookupCacheTtlMs = 30000,
+    mdbTrackidLookupCache = {},
+    mdbTrackidLookupInflight = {};
+
+function normalizeTrackIdLookupUrl( playerUrl ) {
+    if( !playerUrl ) {
+        return "";
+    }
+
+    var normalized = String( playerUrl ).trim(),
+        decodeAttempts = 0;
+
+    while( decodeAttempts < 2 ) {
+        try {
+            var decoded = decodeURIComponent( normalized );
+
+            if( decoded == normalized ) {
+                break;
+            }
+
+            normalized = decoded;
+        } catch( error ) {
+            break;
+        }
+
+        decodeAttempts++;
+    }
+
+    if( /[?&]url=/.test( normalized ) ) {
+        normalized = extractUrlFromUrlParameter( normalized );
+    }
+
+    normalized = remove_mdbVariant_fromUrlStr( normalized );
+    normalized = normalizePlayerUrl( normalized );
+
+    if( /^youtu\.be\//.test( normalized ) || /youtube\.com\/watch\?v=/.test( normalized ) ) {
+        normalized = changeYoutubeUrlVariant( normalized, "youtube.com" ) || normalized;
+        normalized = normalizePlayerUrl( normalized );
+    }
+
+    normalized = removeTrackingParameters( normalized );
+
+    return normalized;
+}
+
+function getTrackIdLookupCacheEntry( lookupUrl ) {
+    var cacheEntry = mdbTrackidLookupCache[lookupUrl];
+
+    if( !cacheEntry ) {
+        return null;
+    }
+
+    if( Date.now() - cacheEntry.timestamp > mdbTrackidLookupCacheTtlMs ) {
+        delete mdbTrackidLookupCache[lookupUrl];
+        return null;
+    }
+
+    return cacheEntry.data;
+}
+
+function setTrackIdLookupCacheEntry( lookupUrl, data ) {
+    mdbTrackidLookupCache[lookupUrl] = {
+        timestamp: Date.now(),
+        data: data
+    };
+}
+
+function buildTrackIdLookupApiUrl( action, params ) {
+    var apiQueryUrl = apiUrl_mw + "?action=" + action + "&format=json";
+
+    if( params && params.url ) {
+        apiQueryUrl += "&url=" + encodeURIComponent( params.url );
+    }
+
+    if( params && params.urls ) {
+        apiQueryUrl += "&urls=" + encodeURIComponent( params.urls.join( "|" ) );
+    }
+
+    if( params && params.page_id ) {
+        apiQueryUrl += "&page_id=" + encodeURIComponent( params.page_id );
+    }
+
+    return apiQueryUrl;
+}
+
+function toolkit_requestTrackIdLookup( playerUrl, options ) {
+    options = options || {};
+
+    var lookupUrl = normalizeTrackIdLookupUrl( playerUrl );
+
+    if( !lookupUrl ) {
+        return $.Deferred().reject( {
+            error: {
+                code: "invalidurl",
+                info: "TrackId lookup URL is missing"
+            }
+        } ).promise();
+    }
+
+    var cachedResult = getTrackIdLookupCacheEntry( lookupUrl );
+
+    if( cachedResult ) {
+        return $.Deferred().resolve( cachedResult ).promise();
+    }
+
+    var inflightEntry = mdbTrackidLookupInflight[lookupUrl];
+
+    if( inflightEntry ) {
+        return inflightEntry.promise;
+    }
+
+    var deferred = $.Deferred();
+
+    mdbTrackidLookupInflight[lookupUrl] = {
+        deferred: deferred,
+        promise: deferred.promise()
+    };
+
+    if( options.source ) {
+        logVar( "trackidRequestSource", options.source );
+    }
+
+    var apiQueryUrl = buildTrackIdLookupApiUrl( "mixesdbtrackid", {
+        url: lookupUrl
+    } );
+
+    logVar( "apiQueryUrl_check", apiQueryUrl );
+
+    $.ajax({
+        url: apiQueryUrl,
+        type: 'get',
+        dataType: 'json',
+        async: true
+    }).done(function( data ) {
+        setTrackIdLookupCacheEntry( lookupUrl, data );
+        deferred.resolve( data );
+    }).fail(function( xhr, status, error ) {
+        deferred.reject( error || status || xhr );
+    }).always(function() {
+        delete mdbTrackidLookupInflight[lookupUrl];
+    });
+
+    return deferred.promise();
+}
+
+function toolkit_requestTrackIdBatchLookup( playerUrls, options ) {
+    options = options || {};
+
+    var batchDeferred = $.Deferred(),
+        resultsByUrl = {},
+        waitPromises = [],
+        requestUrls = [],
+        seenUrls = {};
+
+    $.each( playerUrls || [], function( index, playerUrl ) {
+        var lookupUrl = normalizeTrackIdLookupUrl( playerUrl );
+
+        if( !lookupUrl || seenUrls[lookupUrl] ) {
+            return;
+        }
+
+        seenUrls[lookupUrl] = true;
+
+        var cachedResult = getTrackIdLookupCacheEntry( lookupUrl );
+
+        if( cachedResult ) {
+            resultsByUrl[lookupUrl] = cachedResult;
+            return;
+        }
+
+        var inflightEntry = mdbTrackidLookupInflight[lookupUrl];
+
+        if( inflightEntry ) {
+            waitPromises.push( inflightEntry.promise.then(function( data ) {
+                resultsByUrl[lookupUrl] = data;
+                return data;
+            }) );
+            return;
+        }
+
+        var deferred = $.Deferred();
+
+        mdbTrackidLookupInflight[lookupUrl] = {
+            deferred: deferred,
+            promise: deferred.promise()
+        };
+
+        requestUrls.push( lookupUrl );
+        waitPromises.push( deferred.promise().then(function( data ) {
+            resultsByUrl[lookupUrl] = data;
+            return data;
+        }) );
+    });
+
+    if( requestUrls.length === 0 ) {
+        if( waitPromises.length === 0 ) {
+            return batchDeferred.resolve( resultsByUrl ).promise();
+        }
+
+        $.when.apply( $, waitPromises ).then(function() {
+            batchDeferred.resolve( resultsByUrl );
+        }, function( error ) {
+            batchDeferred.reject( error );
+        });
+
+        return batchDeferred.promise();
+    }
+
+    if( options.source ) {
+        logVar( "trackidRequestSource", options.source );
+    }
+
+    var apiQueryUrl = buildTrackIdLookupApiUrl( "mixesdbtrackidbatch", {
+        urls: requestUrls
+    } );
+
+    logVar( "apiQueryUrl_batch", apiQueryUrl );
+
+    $.ajax({
+        url: apiQueryUrl,
+        type: 'get',
+        dataType: 'json',
+        async: true
+    }).done(function( data ) {
+        var responseByUrl = {};
+
+        if( data.error ) {
+            $.each( requestUrls, function( index, lookupUrl ) {
+                var inflightEntry = mdbTrackidLookupInflight[lookupUrl];
+
+                if( inflightEntry ) {
+                    inflightEntry.deferred.reject( data.error );
+                    delete mdbTrackidLookupInflight[lookupUrl];
+                }
+            });
+
+            batchDeferred.reject( data.error );
+            return;
+        }
+
+        $.each( data.mixesdbtrackidbatch || [], function( index, result ) {
+            $.each( [ result.requestedurl, result.sanitizedurl ], function( keyIndex, resultUrl ) {
+                var lookupUrl = normalizeTrackIdLookupUrl( resultUrl );
+
+                if( lookupUrl ) {
+                    responseByUrl[lookupUrl] = result;
+                }
+            });
+        });
+
+        $.each( requestUrls, function( index, lookupUrl ) {
+            var result = responseByUrl[lookupUrl] || {
+                error: {
+                    code: "notfound",
+                    info: "TrackId.net page not found (recently created?)",
+                    url: lookupUrl
+                },
+                mixesdbtrackid: [],
+                __trackidBatchMiss: true
+            },
+                inflightEntry = mdbTrackidLookupInflight[lookupUrl];
+
+            setTrackIdLookupCacheEntry( lookupUrl, result );
+
+            if( inflightEntry ) {
+                inflightEntry.deferred.resolve( result );
+                delete mdbTrackidLookupInflight[lookupUrl];
+            }
+
+            resultsByUrl[lookupUrl] = result;
+        });
+
+        if( waitPromises.length === 0 ) {
+            batchDeferred.resolve( resultsByUrl );
+            return;
+        }
+
+        $.when.apply( $, waitPromises ).then(function() {
+            batchDeferred.resolve( resultsByUrl );
+        }, function( error ) {
+            batchDeferred.reject( error );
+        });
+    }).fail(function( xhr, status, error ) {
+        $.each( requestUrls, function( index, lookupUrl ) {
+            var inflightEntry = mdbTrackidLookupInflight[lookupUrl];
+
+            if( inflightEntry ) {
+                inflightEntry.deferred.reject( error || status || xhr );
+                delete mdbTrackidLookupInflight[lookupUrl];
+            }
+        });
+
+        batchDeferred.reject( error || status || xhr );
+    });
+
+    return batchDeferred.promise();
+}
+
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *
@@ -1161,55 +1459,44 @@ function toolkit_addTidLink( playerUrl, title ) {
 
     // Wait for toolkit
     waitForKeyElements("#mdb-toolkit > ul", function( jNode ) {
-        var apiQueryUrl_check = apiUrl_mw;
-        apiQueryUrl_check += "?action=mixesdbtrackid";
-        apiQueryUrl_check += "&format=json";
-        apiQueryUrl_check += "&url=" + playerUrl;
+        toolkit_requestTrackIdLookup( playerUrl, {
+            source: "toolkit"
+        } ).done(function( data ) {
+            // avoid undefined error
+            if( ( data.error && data.error.code == "notfound" )  ) {
+                // no result
+                var keywords = normalizeTitleForSearch( title ),
+                    tidLink = makeTidSubmitLink( playerUrl, keywords, "text" );
+                if( tidLink ) {
+                    jNode.append( '<li class="mdb-toolkit-tidLink filled">'+tidLink+'</li>' ).show();
+                }
+                // if no error
+            } else {
+                var li_tidLink_out = "",
+                    trackidurl = data.mixesdbtrackid?.[0]?.trackidurl || null,
+                    lastCheckedAgainstMixesDB = data.mixesdbtrackid?.[0]?.mixesdbpages?.[0]?.lastCheckedAgainstMixesDB || null;
 
-        logVar( "apiQueryUrl_check", apiQueryUrl_check );
+                logVar( "trackidurl", trackidurl );
+                logVar( "lastCheckedAgainstMixesDB", lastCheckedAgainstMixesDB );
 
-        $.ajax({
-            url: apiQueryUrl_check,
-            type: 'get', /* GET on checking */
-            dataType: 'json',
-            async: true,
-            success: function(data) {
-                // avoid undefined error
-                if( ( data.error && data.error.code == "notfound" )  ) {
-                    // no result
-                    var keywords = normalizeTitleForSearch( title ),
-                        tidLink = makeTidSubmitLink( playerUrl, keywords, "text" );
-                    if( tidLink ) {
-                        jNode.append( '<li class="mdb-toolkit-tidLink filled">'+tidLink+'</li>' ).show();
-                    }
-                    // if no error
-                } else {
-                    var li_tidLink_out = "",
-                        trackidurl = data.mixesdbtrackid?.[0]?.trackidurl || null,
-                        lastCheckedAgainstMixesDB = data.mixesdbtrackid?.[0]?.mixesdbpages?.[0]?.lastCheckedAgainstMixesDB || null;
-
-                    logVar( "trackidurl", trackidurl );
-                    logVar( "lastCheckedAgainstMixesDB", lastCheckedAgainstMixesDB );
-
-                    if( trackidurl ) {
-                        li_tidLink_out += '<a href="'+trackidurl+'">This player exists on TrackId.net</a>';
-                    }
-
-                    if( lastCheckedAgainstMixesDB ) {
-                        li_tidLink_out += ' <span id="mdbTrackidCheck-wrapper" class="integrated">'+checkIcon+'integrated</span>';
-                        li_tidLink_out += ' ' + toolkit_tidLastCheckedText( lastCheckedAgainstMixesDB );
-                    } else {
-                        li_tidLink_out += ' (not integrated yet)';
-                    }
-
-                    if( li_tidLink_out != "" ) {
-                        jNode.append( '<li class="mdb-toolkit-tidLink filled">'+li_tidLink_out+'</li>' ).show();
-                    }
+                if( trackidurl ) {
+                    li_tidLink_out += '<a href="'+trackidurl+'">This player exists on TrackId.net</a>';
                 }
 
-                reorderToolkitItems();
+                if( lastCheckedAgainstMixesDB ) {
+                    li_tidLink_out += ' <span id="mdbTrackidCheck-wrapper" class="integrated">'+checkIcon+'integrated</span>';
+                    li_tidLink_out += ' ' + toolkit_tidLastCheckedText( lastCheckedAgainstMixesDB );
+                } else {
+                    li_tidLink_out += ' (not integrated yet)';
+                }
+
+                if( li_tidLink_out != "" ) {
+                    jNode.append( '<li class="mdb-toolkit-tidLink filled">'+li_tidLink_out+'</li>' ).show();
+                }
             }
-        }); // END ajax
+
+            reorderToolkitItems();
+        });
     }); // END wait "#mdb-toolkit > ul"
 }
 


### PR DESCRIPTION
Fixes #687.

## Summary
- add a shared TrackId lookup helper with URL normalization, short-lived cache, and in-flight reuse
- migrate helper/toolkit single lookups to the shared helper
- migrate TrackId single and batch flows to the shared helper
- preserve batch result normalization and existing search-keyword fallback behavior for batch misses

## Validation
- node --check includes/toolkit.js
- node --check MixesDB_Userscripts_Helper/script.user.js
- node --check TrackId.net/script.user.js
- git diff --check