### PR TITLE
Automate a click on "TID tracklist is integrated" when the mix page t…

### DIFF
--- a/TrackId.net/README.md
+++ b/TrackId.net/README.md
@@ -84,13 +84,19 @@ link, with a **Report** link behind it – see
 [Tracklist Importer](../shared/tracklist_importer/) (beta). It opens the mix page's edit form
 with the tracklist already inserted or merged and MediaWiki's own diff on screen; nothing is
 saved for you. A mix page that already holds everything the found tracklist has gets no link –
-there would be nothing to merge.
+there would be nothing to merge – but a note saying which of the two cases it is: **Identical**
+(the same list on both sides) or **Nothing to add** (the page has that and more).
 
 ### Mark as integrated
 
 A **TID tracklist is integrated** checkbox next to the MixesDB page link records that this TID
 tracklist has been carried over. Pages already marked show a check mark and how long ago that
 happened.
+
+The checkbox ticks itself when the [Tracklist Importer](../shared/tracklist_importer/) finds the
+mix page's tracklist and this one to be the same list – the **Identical** note in the same row.
+Nothing else ticks it for you: a page that merely holds everything this tracklist has stays
+untouched, and so does one the merge could still add something to.
 
 ### Real tables instead of the data grid
 

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TrackId.net (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.27.3
+// @version      2026.08.27.4
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -13,8 +13,8 @@
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/global.js?v-TrackId.net_114
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/tracklist_editor/funcs.js?v-TrackId.net_19
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/toolkit/funcs.js?v-TrackId.net_130
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/tracklist_importer/merge_core.js?v-TrackId.net_6
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/tracklist_importer/funcs.js?v-TrackId.net_22
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/tracklist_importer/merge_core.js?v-TrackId.net_7
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/tracklist_importer/funcs.js?v-TrackId.net_23
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/page_creator/title_definitions.js?v_57
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/page_creator/title_builder.js?v_88
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/shared/page_creator/tracklist_detector.js?v_13
@@ -37,7 +37,7 @@
  * global.js URL needs to be changed manually
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-var cacheVersion = 195,
+var cacheVersion = 196,
     scriptName = "TrackId.net";
 window.scriptName = scriptName; // toolkit.js reads this global directly
 window.cacheVersion = cacheVersion; // same reason: the @require'd shared files cache-bust their own CSS with it

--- a/shared/tracklist_importer/CLAUDE.md
+++ b/shared/tracklist_importer/CLAUDE.md
@@ -12,7 +12,7 @@ stalled Tracklist Merger userscript (`Tracklist_Merger/`), whose merge logic it 
 | --- | --- |
 | `merge_core.js` | Pure text in, text out: the merge (`tlImporter_merge`), the matching and cue-format helpers, and the wikitext helpers for the `== Tracklist ==` section (`tlImporter_extractTracklist`, `tlImporter_setTracklist`, `tlImporter_tracklistWikitext`, `tlImporter_updateTlCategory`). No DOM, no network, no jQuery – deliberately self-contained (own copies of the normalization regexes), so the deno runner can load it. Keep it that way. |
 | `funcs.js` | The DOM half: the toolkit links and Report box on the player site, the import + review block (Original / Merged / Candidate above the edit box) + Apply + button gating on the mixesdb.com edit form. Loads the CSS lazily (`tlImporter_loadCss`). |
-| `tracklist_importer.css` | Report box, review block, locked-button state. Loaded by `funcs.js`, not by the site scripts. |
+| `tracklist_importer.css` | Report box, the "nothing to merge" note in the toolkit row, review block, locked-button state. Loaded by `funcs.js`, not by the site scripts. |
 | `importer_examples.js` | Test data: merges and page-text cases. Reported merges become cases here, like title reports in `../page_creator/title_examples.js`. |
 | `importer_examples_test.js` | The deno runner for it. |
 
@@ -66,10 +66,27 @@ mixesdb.com/w/*, where `funcs.js` reads it back.
   edit box. The one synchronous TLE call only supplies the verdict (category + icons) and the
   re-rendered feedback; it never rewrites the text. The seq bump on the box drops the blur
   update the click itself triggered, so nothing reformats the box behind the apply either.
-- **A merge that would change nothing gets no link.** `changed` is read off the merged TEXT,
-  not off the write counter in `state.changes`: writing a value the original already carried
-  counted as a change and produced a link into a `(No difference)` diff. The link builder runs
-  the merge itself for this – it is pure JS, so that costs nothing but a few ms.
+- **A merge that would change nothing gets no link, but a NOTE.** `changed` is read off the
+  merged TEXT, not off the write counter in `state.changes`: writing a value the original
+  already carried counted as a change and produced a link into a `(No difference)` diff. The
+  link builder runs the merge itself for this – it is pure JS, so that costs nothing but a few
+  ms. The spot the link would have taken stays occupied by `tlImporter_addNoMergeNote()`: an
+  empty action row is indistinguishable from an importer that never ran.
+- **"Identical" is the certain reading, and it is the one that acts by itself.**
+  `tlImporter_sameTracklists()` (merge_core.js, reported through `identical` on the merge
+  result) answers it off the MERGE, never off the two texts – cue format, spelling and labels
+  differ between page and player site by nature, and only the matcher knows which row is which.
+  All of: nothing written, every candidate row matched 1:1 (not inserted, no two rows on the
+  same original row, nothing on it `tlImporter_candidateUse()` could not place) and no original
+  row or gap left over. Only that ticks the toolkit's "TID tracklist is integrated" checkbox
+  (`tlImporter_tickIntegrated()`, a native `.click()` so TrackId.net's own handler does the
+  saving – which POSTs, and the site knows no way back). A candidate merely CONTAINED in a
+  longer original is not identical: it reads "Nothing to add" and ticks nothing, because the
+  page then knows more than the player site and only the reader can judge that.
+  The tick has to WAIT: the checkbox arrives hidden and TrackId.net only shows it once its own
+  check request came home – an answer that may replace the input with the check mark (already
+  integrated) or the whole wrapper with a sentence (player unknown to the API). Hence the poll
+  for a VISIBLE input, and the give-up after ~15s that every other site runs into.
 - **Save is locked until "Show changes" ran.** The auto-click is the convenience; the lock is
   the safety – a merge must not be savable unseen.
 - **The original's cue format wins, but it may WIDEN – the dur fix.** A bare `[XX]` format

--- a/shared/tracklist_importer/README.md
+++ b/shared/tracklist_importer/README.md
@@ -19,11 +19,20 @@ page's current text is checked:
 
 - **no tracklist yet** – an **Insert** link appears in front of the toolkit's EDIT link
 - **a tracklist exists** – a **Merge** link appears there instead
-- **a tracklist that already holds everything the found one has** – no link at all: the merge
-  is tried before the link is offered, and one that would leave the page text as it is only
-  leads to MediaWiki's "(No difference)"
+- **a tracklist that already holds everything the found one has** – no link, but a short note
+  in its place saying so: **Identical** when the two lists are the same list, **Nothing to add**
+  when the page holds everything the found tracklist has and more. The merge is tried before the
+  link is offered, and one that would leave the page text as it is only leads to MediaWiki's
+  "(No difference)". Hover the note for the reason.
 
-Both open the mix page's edit form in a new tab with the work already done.
+Both links open the mix page's edit form in a new tab with the work already done.
+
+**Identical** also ticks the toolkit's **TID tracklist is integrated** checkbox for you: when the
+mix page carries exactly this tracklist, it *is* integrated. It is the certain reading – every
+track of the found tracklist sits on the page, the page has no track the found one is missing,
+and there is nothing left over the merge could not place. **Nothing to add** never ticks anything:
+the page knows more than the found tracklist there, and whether that counts as integrated is your
+call.
 
 ### Insert
 

--- a/shared/tracklist_importer/funcs.js
+++ b/shared/tracklist_importer/funcs.js
@@ -119,6 +119,64 @@ function tlImporter_fetchPageText( pageId, done ) {
     });
 }
 
+// tlImporter_addNoMergeNote
+// What stands where the Insert/Merge link would be when there is nothing to merge. That spot
+// used to stay empty, which reads exactly like "the importer did not run" - and the reader
+// has no way of telling the two apart.
+//
+// Two readings, because "nothing to merge" has two very different meanings (see
+// tlImporter_sameTracklists in merge_core.js):
+//   "Identical"      - the same list on both sides. The found tracklist IS in the mix page,
+//                      so the toolkit's "TID tracklist is integrated" checkbox is ticked too.
+//   "Nothing to add" - the page holds everything the found tracklist has AND more. No claim
+//                      is made about it: the reader decides whether that counts as integrated.
+function tlImporter_addNoMergeNote( wrapper, editLink, identical ) {
+    var note = $( '<span class="mdb-element mdb-tlImporter-note"></span>' )
+        .attr( "title", identical
+            ? "This tracklist and the tracklist of the MixesDB page are the same list - nothing to merge.\nMarked as integrated for you."
+            : "The MixesDB page's tracklist already holds everything this tracklist could add - nothing to merge." )
+        .text( identical ? "Identical" : "Nothing to add" );
+
+    if( identical ) note.addClass( "mdb-tlImporter-note-identical" );
+
+    // same divider the links get, so [note] | [EDIT HIST] groups the same way
+    editLink.before( note, $( '<span class="mdb-element mdb-toolkit-actionDivider"></span>' ) );
+
+    if( identical ) tlImporter_tickIntegrated( wrapper );
+}
+
+// tlImporter_tickIntegrated
+// Ticks the toolkit's "TID tracklist is integrated" checkbox of THIS usage row, by clicking
+// it: the saving belongs to the site script's own handler (TrackId.net/script.user.js), and a
+// silently set property would not reach it.
+//
+// It has to wait for that handler's own answer first. The checkbox arrives hidden and is only
+// shown once the check request came home - and that answer may be "already integrated", which
+// replaces the input with the check mark, or "no such player", which replaces the whole
+// wrapper with a sentence. So: poll for a VISIBLE input, stop as soon as the input is gone,
+// and give up after ~15s (every site but TrackId.net never shows the wrapper at all).
+function tlImporter_tickIntegrated( wrapper ) {
+    var tries = 0,
+        timer = setInterval(function() {
+            var box = wrapper.find( "input.mdbTrackidCheck" );
+
+            if( ++tries > 50 || !box.length || !wrapper.closest( "body" ).length ) {
+                clearInterval( timer );
+                return;
+            }
+
+            if( !box.is( ":visible" ) ) return; // the check request has not answered yet
+
+            clearInterval( timer );
+
+            if( box.prop( "checked" ) ) return;
+
+            log( "tlImporter: the two tracklists are identical - ticking the integrated checkbox." );
+
+            box[0].click(); // native, so the site script's own click handler does the saving
+        }, 300 );
+}
+
 // The links, one wrapper at a time. Registered once at the top level; the handler returns true
 // (= not handled, keep polling) until the page also has a filled candidate box, because a
 // toolkit link without a tracklist to carry would only ever insert nothing.
@@ -167,9 +225,16 @@ if( typeof visitDomain !== "undefined" && visitDomain != "mixesdb.com" ) {
             // A merge that would change nothing is not worth a link: following it would only
             // open the edit form on MediaWiki's "(No difference)". The merge itself is the
             // answer - pure JS, no network - and the candidate is re-read from the box here,
-            // because the page text fetch above was async.
-            if( mode == "merge" && !tlImporter_merge( read.tlText, tlImporter_candidateText() ).changed ) {
-                log( "tlImporter: the mix page tracklist already holds everything this candidate could add - no import link." );
+            // because the page text fetch above was async. A note takes the link's place, so
+            // the row does not read as "the importer never ran" - see tlImporter_addNoMergeNote.
+            var mergeTry = mode == "merge" ? tlImporter_merge( read.tlText, tlImporter_candidateText() ) : null;
+
+            if( mergeTry && !mergeTry.changed ) {
+                log( "tlImporter: the mix page tracklist already holds everything this candidate could add - no import link"
+                     + ( mergeTry.identical ? ", the two lists are identical." : "." ) );
+
+                tlImporter_loadCss();
+                tlImporter_addNoMergeNote( jNode, editLink, mergeTry.identical );
                 return;
             }
 

--- a/shared/tracklist_importer/importer_examples.js
+++ b/shared/tracklist_importer/importer_examples.js
@@ -56,6 +56,9 @@ var tlImporterExamples_merge = [
         candidate: "[00] A - One [CandLabel]\n[03] ?\n[10] B - Two",
         expect: "[00] A - One [OrigLabel]\n[10] B - Two",
         changed: false,
+        // not identical: the candidate has a label the page carries differently and a "?" row
+        // the merge dropped - both are things a reader may still want to look at
+        identical: false,
         unused: { cues: [2], texts: [], labels: [1] }
     },
     {
@@ -209,6 +212,20 @@ var tlImporterExamples_merge = [
                 "[038] ?\n" +
                 "...",
         changed: false,
+        identical: true,
+        unused: { cues: [], texts: [], labels: [] }
+    },
+    {
+        // The weaker no-change shape: everything the candidate has is on the page, but the
+        // page knows more (a track the candidate never found). Nothing to merge either way,
+        // but this is NOT the same list - and the "Identical" note plus the automatic
+        // "TID tracklist is integrated" tick hang off that difference.
+        name: "candidate contained in a longer original",
+        original: "[00] A - One\n[10] B - Two\n[20] C - Three",
+        candidate: "[00] A - One\n[10] B - Two",
+        expect: "[00] A - One\n[10] B - Two\n[20] C - Three",
+        changed: false,
+        identical: false,
         unused: { cues: [], texts: [], labels: [] }
     },
     {

--- a/shared/tracklist_importer/importer_examples_test.js
+++ b/shared/tracklist_importer/importer_examples_test.js
@@ -61,6 +61,11 @@ for( const c of tlImporterExamples_merge ) {
     report( res.mergedText === c.expect, c.name + " [merged text]", res.mergedText, c.expect );
     report( res.changed === c.changed, c.name + " [changed flag]", res.changed, c.changed );
 
+    // only cases that state one - identical is the strict reading of a no-change merge
+    if( typeof c.identical === "boolean" ) {
+        report( res.identical === c.identical, c.name + " [identical flag]", res.identical, c.identical );
+    }
+
     if( c.unused ) {
         for( const part of [ "cues", "texts", "labels" ] ) {
             const key = part.replace( /s$/, "" ),

--- a/shared/tracklist_importer/merge_core.js
+++ b/shared/tracklist_importer/merge_core.js
@@ -942,9 +942,75 @@ function tlImporter_originalItems( merged_arr ) {
     return items;
 }
 
+// tlImporter_sameTracklists
+// Do the two lists say the SAME thing? Read off the MERGE, never off the two texts: the
+// candidate's cue format, its spelling and the labels it carries differ from the page's by
+// nature, and only the matcher knows which row over here is which row over there.
+//
+// True only when all three hold:
+//   - the merge wrote nothing into the page (changed = false)
+//   - every candidate row found its counterpart in the original – matched, not inserted, no
+//     two candidate rows on the same original row, and nothing on it the merge could not
+//     place (tlImporter_candidateUse: a label the page has differently, a cue that disagrees)
+//   - no original row was left without a candidate, gaps counted
+//
+// A candidate that is merely CONTAINED in a longer original is deliberately not identical:
+// the page then knows more than the candidate, and the callers act unattended on this flag
+// (the "TID tracklist is integrated" checkbox), so it has to mean certainty, not "close
+// enough".
+function tlImporter_sameTracklists( merged_arr, candidate_arr, changed ) {
+    if (changed) return false;
+
+    var matchedOrigs = [],
+        candTracks = 0,
+        candGaps = 0,
+        allMatched = true;
+
+    candidate_arr.forEach(function( cand ) {
+        if (cand.type === "gap") {
+            candGaps++;
+            return;
+        }
+
+        if (cand.type !== "track") return; // "track (false)" never took part in the merge
+
+        candTracks++;
+
+        if (!cand._ti_matchedOrig || cand._ti_inserted) {
+            allMatched = false;
+            return;
+        }
+
+        // a part the merge could not place is something the reader may still want to salvage
+        // by hand – two lists with one of those in them are not the same list
+        var use = tlImporter_candidateUse( cand );
+
+        if (!use.cue || !use.text || !use.label) {
+            allMatched = false;
+            return;
+        }
+
+        if (matchedOrigs.indexOf( cand._ti_matchedOrig ) === -1) matchedOrigs.push( cand._ti_matchedOrig );
+    });
+
+    if (!allMatched || matchedOrigs.length !== candTracks) return false;
+
+    // The original rows inside the merged array are the ones carrying a pre-merge snapshot
+    // (_ti_before) resp. the _ti_origGap flag – everything else was spliced in by the merge.
+    var origTracks = 0,
+        origGaps = 0;
+
+    merged_arr.forEach(function( item ) {
+        if (item.type === "track" && item._ti_before) origTracks++;
+        if (item.type === "gap" && item._ti_origGap) origGaps++;
+    });
+
+    return matchedOrigs.length === origTracks && candGaps === origGaps;
+}
+
 // tlImporter_merge
 // The one entry the site code calls: original text + candidate text in, merged text (raw, NOT
-// yet TLE-formatted), a changed flag and the candidate diff rows out.
+// yet TLE-formatted), a changed flag, an identical flag and the candidate diff rows out.
 function tlImporter_merge( originalText, candidateText ) {
     var original_arr = tlImporter_parse( originalText ),
         candidate_arr = tlImporter_parse( candidateText );
@@ -1038,9 +1104,13 @@ function tlImporter_merge( originalText, candidateText ) {
     var mergedText = tlImporter_textFromArr( merged_arr ),
         originalText_serialized = tlImporter_textFromArr( tlImporter_parse( originalText ) );
 
+    var changed = state.changes > 0 && mergedText !== originalText_serialized;
+
     return {
         mergedText: mergedText,
-        changed: state.changes > 0 && mergedText !== originalText_serialized,
+        changed: changed,
+        // the certain "these two are the same list" reading – see tlImporter_sameTracklists
+        identical: tlImporter_sameTracklists( merged_arr, candidate_arr, changed ),
         diffItems: tlImporter_diffItems( candidate_arr ),
         originalItems: tlImporter_originalItems( merged_arr )
     };

--- a/shared/tracklist_importer/tracklist_importer.css
+++ b/shared/tracklist_importer/tracklist_importer.css
@@ -5,7 +5,8 @@
  * Loaded lazily by funcs.js (tlImporter_loadCss) on both sides: the player site showing the
  * Insert/Merge/Report links, and the MixesDB edit form showing the review block.
  * The links themselves need no rules of their own - they sit inside the toolkit's
- * .mdb-mixesdbLink-actionLinks-wrapper, whose global.css rules style every <a> in it.
+ * .mdb-mixesdbLink-actionLinks-wrapper, whose global.css rules style every <a> in it. The
+ * "nothing to merge" note is the one thing there that is NOT an <a>, so it brings its own.
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -19,6 +20,24 @@
     font-family: monospace, monospace;
     font-size: 12px;
     line-height: 1.4;
+}
+
+/* the "Identical" / "Nothing to add" note in the toolkit's action row, standing where the
+ * Insert/Merge link would be. Deliberately NOT pill-shaped like the links around it: there is
+ * nothing to click here, it is a statement about the two tracklists. The row's own font-size
+ * is inherited; the help cursor announces the tooltip that carries the reason. */
+.mdb-mixesdbLink-actionLinks-wrapper .mdb-tlImporter-note {
+    padding: 1px 2px;
+    opacity: .62;
+    cursor: help;
+    white-space: nowrap;
+}
+
+/* the certain half of it - the same list on both sides, and the "TID tracklist is integrated"
+   checkbox was ticked from it. Full strength instead of a colour: the toolkit runs on bright
+   and on dark sites, and no one green reads well on both. */
+.mdb-mixesdbLink-actionLinks-wrapper .mdb-tlImporter-note-identical {
+    opacity: 1;
 }
 
 /* the review block between MediaWiki's diff and the wiki edit box (mixesdb.com).


### PR DESCRIPTION
…l is identical to the TID t